### PR TITLE
refactor(core): move Consistency enum into solver module

### DIFF
--- a/dbcop_core/src/lib.rs
+++ b/dbcop_core/src/lib.rs
@@ -8,12 +8,4 @@ pub mod graph;
 pub mod history;
 pub mod solver;
 
-#[derive(Debug, Copy, Clone)]
-pub enum Consistency {
-    CommittedRead,
-    AtomicRead,
-    Causal,
-    Prefix,
-    SnapshotIsolation,
-    Serializable,
-}
+pub use solver::Consistency;

--- a/dbcop_core/src/solver/mod.rs
+++ b/dbcop_core/src/solver/mod.rs
@@ -5,3 +5,14 @@ pub mod saturation;
 // Re-export submodules at the solver level for backwards compatibility.
 pub use linearization::{constrained_linearization, prefix, serializable, snapshot_isolation};
 pub use saturation::{atomic_read, causal, committed_read, repeatable_read};
+
+/// Consistency levels supported by dbcop, ordered from weakest to strongest.
+#[derive(Debug, Copy, Clone)]
+pub enum Consistency {
+    CommittedRead,
+    AtomicRead,
+    Causal,
+    Prefix,
+    SnapshotIsolation,
+    Serializable,
+}


### PR DESCRIPTION
## Summary
- Move `Consistency` enum from `lib.rs` to `solver/mod.rs`
- Re-export from `lib.rs` via `pub use solver::Consistency` -- public API unchanged
- No logic changes

## Motivation
The `Consistency` enum logically belongs with the solvers that implement each level, not at the crate root.

## Test plan
- [x] `cargo test -p dbcop_core` -- 30 tests pass
- [x] `cargo build -p dbcop_core --no-default-features` -- no_std preserved
- [x] External imports (`dbcop_core::Consistency`) still work via re-export

🤖 Generated with [Claude Code](https://claude.com/claude-code)