### PR TITLE
chore: fix clippy warnings and lint config (Pass A verification)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,14 +41,14 @@ derive_more = { version = "0.99" }
 unused_qualifications = "warn"
 
 [workspace.lints.clippy]
-all = "warn"
-nursery = "warn"
-cargo = "warn"
-pedantic = "warn"
+all = { level = "warn", priority = -1 }
+nursery = { level = "warn", priority = -1 }
+cargo = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
 module_name_repetitions = "allow"
 mod_module_files = "allow"
 exhaustive_structs = "allow"
 exhaustive_enums = "allow"
 missing_inline_in_public_items = "allow"
 implicit_return = "allow"
-missing_trait_method = "allow"
+missing_trait_methods = "allow"

--- a/dbcop_core/src/history/atomic/mod.rs
+++ b/dbcop_core/src/history/atomic/mod.rs
@@ -51,7 +51,7 @@ where
                     session_order.add_edge(*t1, *t2);
                 } else {
                     session_order.add_edge(TransactionId::default(), *t2);
-                };
+                }
             }
         }
 

--- a/dbcop_testgen/src/generator.rs
+++ b/dbcop_testgen/src/generator.rs
@@ -28,7 +28,7 @@ pub struct History {
 
 impl History {
     #[must_use]
-    pub fn new(
+    pub const fn new(
         params: HistParams,
         info: String,
         start: DateTime<Local>,


### PR DESCRIPTION
## Summary
- Fix lint group priority in workspace `Cargo.toml` (`all`, `nursery`, `cargo`, `pedantic` need `priority = -1`)
- Fix typo: `missing_trait_method` -> `missing_trait_methods`
- Remove unnecessary semicolon in `atomic/mod.rs`
- Add `const` to `History::new()` in testgen

## Context
Pass A verification gate (task A5). All structural renames from A1-A4 are merged. This cleans up clippy warnings.

## Verification
- [x] `cargo test --workspace` -- 30 tests pass
- [x] `cargo build -p dbcop_core --no-default-features` -- no_std preserved
- [x] `cargo clippy --workspace` -- only unavoidable `multiple_crate_versions` warning remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)