### PR TITLE
chore: update deps, remove unused ascent, unify hashbrown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,14 +24,13 @@ readme = "README.md"
 [workspace.dependencies]
 dbcop_core = { version = "0.2.0", path = "dbcop_core" }
 
-clap = { version = "4.4" }
+clap = { version = "4.5" }
 petgraph = { version = "0.6" }
 tracing = { version = "0.1" }
 serde = { version = "1.0" }
-hashbrown = { version = "0.14" }
-wasm-bindgen = { version = "=0.2.92" }
+hashbrown = { version = "0.15" }
+wasm-bindgen = { version = "0.2" }
 typed-builder = { version = "0.18" }
-ascent = { version = "0.6.0" }
 chrono = { version = "0.4" }
 rand = { version = "0.8" }
 rayon = { version = "1.10" }
@@ -41,14 +40,14 @@ derive_more = { version = "0.99" }
 unused_qualifications = "warn"
 
 [workspace.lints.clippy]
-all = "warn"
-nursery = "warn"
-cargo = "warn"
-pedantic = "warn"
+all = { level = "warn", priority = -1 }
+nursery = { level = "warn", priority = -1 }
+cargo = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
 module_name_repetitions = "allow"
 mod_module_files = "allow"
 exhaustive_structs = "allow"
 exhaustive_enums = "allow"
 missing_inline_in_public_items = "allow"
 implicit_return = "allow"
-missing_trait_method = "allow"
+missing_trait_methods = "allow"

--- a/dbcop_core/Cargo.toml
+++ b/dbcop_core/Cargo.toml
@@ -13,7 +13,6 @@ readme = "README.md"
 [dependencies]
 hashbrown = { workspace = true }
 serde = { workspace = true, optional = true, features = ["derive"] }
-ascent = { workspace = true }
 tracing = { workspace = true }
 derive_more = { workspace = true }
 

--- a/dbcop_core/src/graph/biconnected_component.rs
+++ b/dbcop_core/src/graph/biconnected_component.rs
@@ -50,7 +50,9 @@ where
             non_group: HashSet::new(),
         };
 
-        for vertex in solver.graph.adj_map.keys() {
+        let mut vertices: Vec<_> = solver.graph.adj_map.keys().collect();
+        vertices.sort();
+        for vertex in vertices {
             match graph
                 .adj_map
                 .get(vertex)
@@ -135,13 +137,15 @@ where
         self.lowpoint.insert(vertex.clone(), depth);
         self.dfs_stack.push(vertex.clone());
 
-        for neighbor in self
+        let mut neighbors: Vec<_> = self
             .graph
             .adj_map
             .get(vertex)
             .iter()
             .flat_map(|neighbors| neighbors.iter())
-        {
+            .collect();
+        neighbors.sort();
+        for neighbor in neighbors {
             if !self.visited.contains(neighbor) {
                 self.parent.insert(neighbor.clone(), vertex.clone());
                 self.vertex_components_helper(neighbor, depth + 1);

--- a/dbcop_core/src/history/atomic/mod.rs
+++ b/dbcop_core/src/history/atomic/mod.rs
@@ -51,7 +51,7 @@ where
                     session_order.add_edge(*t1, *t2);
                 } else {
                     session_order.add_edge(TransactionId::default(), *t2);
-                };
+                }
             }
         }
 

--- a/dbcop_testgen/src/generator.rs
+++ b/dbcop_testgen/src/generator.rs
@@ -28,7 +28,7 @@ pub struct History {
 
 impl History {
     #[must_use]
-    pub fn new(
+    pub const fn new(
         params: HistParams,
         info: String,
         start: DateTime<Local>,


### PR DESCRIPTION
## Summary
- Remove unused `ascent` dependency from `dbcop_core` (was imported but never used in any `.rs` file)
- Upgrade `hashbrown` 0.14 -> 0.15 -- eliminates duplicate hashbrown versions in the dep tree
- Upgrade `clap` 4.4 -> 4.5, remove exact pin on `wasm-bindgen`
- Drop patch versions from workspace dep specs (semver compatible ranges)
- Fix lint group priority config and `missing_trait_methods` typo
- Fix non-deterministic DFS in biconnected component walker (sort vertices/neighbors before iteration)
- Fix clippy warnings (unnecessary semicolon, const fn)

## Why the biconnected component fix
hashbrown 0.15 uses a different hash function (`foldhash` instead of `ahash`), which changes HashMap iteration order. The biconnected component DFS was order-dependent, producing different (incorrect) results. Sorting before iteration makes it deterministic.

## Test plan
- [x] `cargo test --workspace` -- 30 tests pass
- [x] `cargo clippy --workspace` -- zero warnings
- [x] `cargo tree -d` -- no duplicate dependencies
- [x] `cargo build -p dbcop_core --no-default-features` -- no_std preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)