### PR TITLE
Wire dbcop_cli to dbcop_core and dbcop_testgen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
   "dbcop_core",
   "dbcop_testgen",
+  "dbcop_cli",
 ]
 
 [workspace.package]
@@ -23,8 +24,10 @@ readme = "README.md"
 
 [workspace.dependencies]
 dbcop_core = { version = "0.2.0", path = "dbcop_core" }
+dbcop_testgen = { version = "0.2.0", path = "dbcop_testgen" }
 
-clap = { version = "4.5" }
+clap = { version = "4.5", features = ["derive"] }
+serde_json = { version = "1.0" }
 petgraph = { version = "0.6" }
 tracing = { version = "0.1" }
 serde = { version = "1.0" }

--- a/dbcop_cli/Cargo.toml
+++ b/dbcop_cli/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "dbcop"
+version.workspace = true
+description.workspace = true
+license.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+readme = "README.md"
+
+[dependencies]
+dbcop_core = { workspace = true, features = ["serde"] }
+dbcop_testgen = { workspace = true }
+
+clap = { workspace = true }
+serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/dbcop_cli/src/lib.rs
+++ b/dbcop_cli/src/lib.rs
@@ -1,0 +1,18 @@
+//! dbcop CLI -- generate and verify transactional histories.
+
+use clap::{Parser, Subcommand};
+
+#[derive(Debug, Parser)]
+#[command(name = "dbcop", about = "Runtime monitoring for transactional consistency")]
+pub struct App {
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    /// Generate random transactional histories
+    Generate,
+    /// Verify consistency of transactional histories
+    Verify,
+}

--- a/dbcop_cli/src/main.rs
+++ b/dbcop_cli/src/main.rs
@@ -1,0 +1,10 @@
+use clap::Parser;
+use dbcop::{App, Command};
+
+fn main() {
+    let app = App::parse();
+    match app.command {
+        Command::Generate => todo!("generate subcommand"),
+        Command::Verify => todo!("verify subcommand"),
+    }
+}


### PR DESCRIPTION
## Summary
- Add `dbcop_cli` to workspace members
- Add `dbcop_core` (with serde feature) and `dbcop_testgen` as dependencies
- Add `serde_json` and `dbcop_testgen` to workspace dependencies
- Set up clap CLI skeleton with `generate` and `verify` subcommands (todo stubs)

## Test plan
- [x] `cargo build -p dbcop` compiles
- [x] `cargo clippy --workspace --all-features -- -D warnings` passes
- [x] `cargo test --workspace --all-features` passes (30 tests)
- [x] `cargo run -p dbcop -- --help` shows generate and verify subcommands

🤖 Generated with [Claude Code](https://claude.com/claude-code)