### PR TITLE
Implement generate and verify CLI subcommands

### DIFF
--- a/dbcop_cli/src/lib.rs
+++ b/dbcop_cli/src/lib.rs
@@ -1,6 +1,8 @@
 //! dbcop CLI -- generate and verify transactional histories.
 
-use clap::{Parser, Subcommand};
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand, ValueEnum};
 
 #[derive(Debug, Parser)]
 #[command(name = "dbcop", about = "Runtime monitoring for transactional consistency")]
@@ -12,7 +14,62 @@ pub struct App {
 #[derive(Debug, Subcommand)]
 pub enum Command {
     /// Generate random transactional histories
-    Generate,
+    Generate(GenerateArgs),
     /// Verify consistency of transactional histories
-    Verify,
+    Verify(VerifyArgs),
+}
+
+#[derive(Debug, Parser)]
+pub struct GenerateArgs {
+    /// Number of histories to generate
+    #[arg(long)]
+    pub n_hist: u64,
+    /// Number of nodes (sessions)
+    #[arg(long)]
+    pub n_node: u64,
+    /// Number of variables
+    #[arg(long)]
+    pub n_var: u64,
+    /// Number of transactions per node
+    #[arg(long)]
+    pub n_txn: u64,
+    /// Number of events per transaction
+    #[arg(long)]
+    pub n_evt: u64,
+    /// Output directory for generated history files
+    #[arg(long)]
+    pub output_dir: PathBuf,
+}
+
+#[derive(Debug, Parser)]
+pub struct VerifyArgs {
+    /// Input directory containing history JSON files
+    #[arg(long)]
+    pub input_dir: PathBuf,
+    /// Consistency level to check
+    #[arg(long)]
+    pub consistency: ConsistencyLevel,
+}
+
+#[derive(Debug, Clone, ValueEnum)]
+pub enum ConsistencyLevel {
+    CommittedRead,
+    AtomicRead,
+    Causal,
+    Prefix,
+    SnapshotIsolation,
+    Serializable,
+}
+
+impl From<ConsistencyLevel> for dbcop_core::Consistency {
+    fn from(level: ConsistencyLevel) -> Self {
+        match level {
+            ConsistencyLevel::CommittedRead => Self::CommittedRead,
+            ConsistencyLevel::AtomicRead => Self::AtomicRead,
+            ConsistencyLevel::Causal => Self::Causal,
+            ConsistencyLevel::Prefix => Self::Prefix,
+            ConsistencyLevel::SnapshotIsolation => Self::SnapshotIsolation,
+            ConsistencyLevel::Serializable => Self::Serializable,
+        }
+    }
 }

--- a/dbcop_cli/src/main.rs
+++ b/dbcop_cli/src/main.rs
@@ -1,10 +1,99 @@
+use std::fs;
+use std::process;
+
 use clap::Parser;
 use dbcop::{App, Command};
 
 fn main() {
     let app = App::parse();
-    match app.command {
-        Command::Generate => todo!("generate subcommand"),
-        Command::Verify => todo!("verify subcommand"),
+    match &app.command {
+        Command::Generate(args) => generate(args),
+        Command::Verify(args) => verify(args),
+    }
+}
+
+fn generate(args: &dbcop::GenerateArgs) {
+    fs::create_dir_all(&args.output_dir).unwrap_or_else(|e| {
+        eprintln!("Failed to create output directory: {e}");
+        process::exit(1);
+    });
+
+    let histories = dbcop_testgen::generator::generate_mult_histories(
+        args.n_hist,
+        args.n_node,
+        args.n_var,
+        args.n_txn,
+        args.n_evt,
+    );
+
+    for history in &histories {
+        let path = args.output_dir.join(format!("{}.json", history.get_id()));
+        let file = fs::File::create(&path).unwrap_or_else(|e| {
+            eprintln!("Failed to create {}: {e}", path.display());
+            process::exit(1);
+        });
+        serde_json::to_writer_pretty(file, history).unwrap_or_else(|e| {
+            eprintln!("Failed to write {}: {e}", path.display());
+            process::exit(1);
+        });
+    }
+
+    println!(
+        "Generated {} histories to {}",
+        histories.len(),
+        args.output_dir.display()
+    );
+}
+
+fn verify(args: &dbcop::VerifyArgs) {
+    let level = dbcop_core::Consistency::from(args.consistency.clone());
+    let mut any_failed = false;
+
+    let mut entries: Vec<_> = fs::read_dir(&args.input_dir)
+        .unwrap_or_else(|e| {
+            eprintln!("Failed to read input directory: {e}");
+            process::exit(1);
+        })
+        .filter_map(Result::ok)
+        .filter(|e| {
+            e.path()
+                .extension()
+                .is_some_and(|ext| ext == "json")
+        })
+        .collect();
+
+    entries.sort_by_key(fs::DirEntry::path);
+
+    if entries.is_empty() {
+        eprintln!("No .json files found in {}", args.input_dir.display());
+        process::exit(1);
+    }
+
+    for entry in entries {
+        let path = entry.path();
+        let filename = path.file_name().unwrap_or_default().to_string_lossy();
+
+        let file = fs::File::open(&path).unwrap_or_else(|e| {
+            eprintln!("Failed to open {filename}: {e}");
+            process::exit(1);
+        });
+
+        let history: dbcop_testgen::generator::History = serde_json::from_reader(file)
+            .unwrap_or_else(|e| {
+                eprintln!("Failed to parse {filename}: {e}");
+                process::exit(1);
+            });
+
+        match dbcop_core::check(history.get_data(), level) {
+            Ok(()) => println!("{filename}: PASS"),
+            Err(e) => {
+                println!("{filename}: FAIL ({e:?})");
+                any_failed = true;
+            }
+        }
+    }
+
+    if any_failed {
+        process::exit(1);
     }
 }


### PR DESCRIPTION
## Summary
- `generate` subcommand: creates random histories via `dbcop_testgen`, writes JSON files to `--output-dir`
- `verify` subcommand: reads `.json` files from `--input-dir`, checks against `--consistency` level, prints PASS/FAIL per file, exits 1 on any failure
- Clap derive-based argument parsing with all parameters from the plan

## Test plan
- [x] `cargo run -p dbcop -- generate --help` shows all args
- [x] `cargo run -p dbcop -- verify --help` shows consistency levels
- [x] `generate --n-hist 3 ...` creates 3 JSON files
- [x] `verify --consistency committed-read` correctly reports results
- [x] `cargo clippy --workspace --all-features -- -D warnings` passes
- [x] `cargo test --workspace --all-features` passes (30 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)