### PR TITLE
chore: add pre-commit hooks with husky

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+# Reject non-ASCII characters in staged .rs .ts .js files
+STAGED=$(git diff --cached --name-only | grep -E '\.(rs|ts|js)$' || true)
+if [ -n "$STAGED" ]; then
+  NON_ASCII=$(echo "$STAGED" | xargs grep -Pln '[^\x00-\x7F]' 2>/dev/null || true)
+  if [ -n "$NON_ASCII" ]; then
+    echo "ERROR: non-ASCII characters found in:"
+    echo "$NON_ASCII"
+    exit 1
+  fi
+fi
+
+# Check Rust formatting
+cargo fmt --check --all

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,8 @@
 {
+  "nodeModulesDir": "auto",
   "tasks": {
-    "wasmbuild": "deno run -A jsr:@deno/wasmbuild@0.21.0 --project dbcop_wasm --out wasmlib"
+    "wasmbuild": "deno run -A jsr:@deno/wasmbuild@0.21.0 --project dbcop_wasm --out wasmlib",
+    "prepare": "deno run -A npm:husky"
   },
   "fmt": {
     "exclude": [".sisyphus"]


### PR DESCRIPTION
Add pre-commit hooks to enforce code quality checks on every commit.

## Hooks Configured

1. **Non-ASCII character check**: Rejects any non-ASCII characters in staged .rs, .ts, .js source files
2. **Rust formatting check**: Ensures cargo fmt --check --all passes before commit

## Setup

The hooks are managed via Deno as an npm dependency:
- deno.json includes nodeModulesDir: auto for npm binary resolution
- deno.json includes prepare task that runs husky initialization
- .husky/pre-commit contains the actual hook logic

## Running Prepare

To initialize the git hooks after cloning:
```sh
deno task prepare
```

Or manually register the hooks directory:
```sh
git config core.hooksPath .husky
```