### PR TITLE
fix(core): return Ok for empty and all-empty-session histories

### DIFF
--- a/dbcop_core/src/consistency/mod.rs
+++ b/dbcop_core/src/consistency/mod.rs
@@ -48,6 +48,12 @@ where
     Variable: Eq + Hash + Clone + Ord,
     Version: Eq + Hash + Clone,
 {
+    // Trivially consistent: no sessions or all sessions empty
+    #[allow(clippy::redundant_closure_for_method_calls)]
+    if sessions.is_empty() || sessions.iter().all(|s| s.is_empty()) {
+        return Ok(());
+    }
+
     match level {
         Consistency::CommittedRead => check_committed_read(sessions),
         Consistency::AtomicRead => check_atomic_read(sessions).map(|_| ()),

--- a/dbcop_core/tests/consistency.rs
+++ b/dbcop_core/tests/consistency.rs
@@ -349,3 +349,39 @@ fn check_dispatch_causal_violation() {
         "should fail causal via check()",
     );
 }
+
+#[test]
+fn test_empty_history_is_valid() {
+    let empty: Vec<Session<&str, u64>> = vec![];
+    for level in [
+        Consistency::CommittedRead,
+        Consistency::AtomicRead,
+        Consistency::Causal,
+        Consistency::Prefix,
+        Consistency::SnapshotIsolation,
+        Consistency::Serializable,
+    ] {
+        assert!(
+            check(&empty, level).is_ok(),
+            "empty history should pass {level:?}",
+        );
+    }
+}
+
+#[test]
+fn test_all_empty_sessions_is_valid() {
+    let all_empty: Vec<Session<&str, u64>> = vec![vec![], vec![], vec![]];
+    for level in [
+        Consistency::CommittedRead,
+        Consistency::AtomicRead,
+        Consistency::Causal,
+        Consistency::Prefix,
+        Consistency::SnapshotIsolation,
+        Consistency::Serializable,
+    ] {
+        assert!(
+            check(&all_empty, level).is_ok(),
+            "all-empty sessions should pass {level:?}",
+        );
+    }
+}


### PR DESCRIPTION
Add early-exit guards in check() function to handle trivially consistent cases:

- Empty sessions slice returns Ok(())
- All sessions are empty (no transactions) returns Ok(())

This optimization avoids unnecessary consistency checking for degenerate cases.

Tests added:
- test_empty_history_is_valid: verifies empty slice passes all 6 consistency levels
- test_all_empty_sessions_is_valid: verifies all-empty sessions pass all 6 consistency levels

All existing tests pass. Clippy clean.