### PR TITLE
perf(saturation): replace closure+is_acyclic with single topological_sort pass

### DIFF
--- a/dbcop_core/src/consistency/saturation/committed_read.rs
+++ b/dbcop_core/src/consistency/saturation/committed_read.rs
@@ -1,7 +1,7 @@
 //! Checks if a valid history is a committed read history.
 
-use ::core::hash::Hash;
-use ::hashbrown::HashMap;
+use core::hash::Hash;
+use hashbrown::HashMap;
 
 use crate::consistency::error::Error;
 use crate::graph::digraph::DiGraph;
@@ -130,10 +130,9 @@ where
         }
     }
 
-    committed_order = committed_order.closure();
-
     committed_order
-        .is_acyclic()
+        .topological_sort()
+        .is_some()
         .then_some(())
         .ok_or(Error::Invalid(Consistency::CommittedRead))
 }


### PR DESCRIPTION
Eliminates redundant double-pass pattern in committed_read.rs acyclicity check.

BEFORE: committed_order.closure() [O(V^2*E)] + is_acyclic() [O(V*(V+E))]
AFTER: committed_order.topological_sort().is_some() [O(V+E)]

The transitive closure computation was only used for the acyclicity check, which is now replaced with a single topological sort pass. This is guaranteed to be correct by T1's Kahn implementation: a graph is acyclic IFF topological_sort().is_some().

All tests pass. No functional changes.