### PR TITLE
fix(testgen): generate valid committed histories with coherent reads

### DIFF
--- a/dbcop_testgen/tests/consistency.rs
+++ b/dbcop_testgen/tests/consistency.rs
@@ -1,1 +1,10 @@
+use dbcop_core::{check, Consistency};
+use dbcop_testgen::generator::generate_single_history;
 
+#[test]
+fn generated_history_satisfies_committed_read() {
+    let sessions = generate_single_history(3, 5, 4, 6);
+    assert!(!sessions.is_empty());
+    check(&sessions, Consistency::CommittedRead)
+        .expect("generated history must satisfy committed-read");
+}


### PR DESCRIPTION
## Summary

- Fix `committed: false` hardcoded in `generate_single_history` -- all generated transactions are now `committed: true`
- Fix read coherence: reads now observe only versions that exist as writes in the history
  - An init transaction (first session) writes all variables at version 0
  - A `latest_writes` map tracks the most recently written version per variable
  - Reads sample from a pre-transaction snapshot (`readable`) so they never read from writes in the same transaction
  - Each variable is read at most once per transaction to avoid self-loop edges in the committed-order graph
- Add integration test: generate a history and verify it passes `CommittedRead` consistency check

## Changes

- `dbcop_testgen/src/generator.rs`: coherent read generation with init transaction and version tracking
- `dbcop_testgen/tests/consistency.rs`: integration test calling `dbcop_core::check()` at `CommittedRead` level