### PR TITLE
chore(hooks): use cargo +nightly fmt in pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -13,4 +13,4 @@ if [ -n "$STAGED" ]; then
 fi
 
 # Check Rust formatting
-cargo fmt --check --all
+cargo +nightly fmt --check --all


### PR DESCRIPTION
Update .husky/pre-commit to use cargo +nightly fmt instead of cargo fmt to match the nightly rustfmt used in CI.