### PR TITLE
feat(core): add serde feature gates for TransactionId and DiGraph edge-list export

### DIFF
--- a/dbcop_core/src/consistency/linearization/constrained_linearization.rs
+++ b/dbcop_core/src/consistency/linearization/constrained_linearization.rs
@@ -7,8 +7,8 @@ use hashbrown::{HashMap, HashSet};
 
 // Zobrist hash: XOR two u64 hashes with different seeds -> u128
 fn zobrist_value<T: Hash>(v: &T) -> u128 {
-    use core::hash::BuildHasher;
-    use core::hash::Hasher;
+    use core::hash::{BuildHasher, Hasher};
+
     use hashbrown::DefaultHashBuilder;
 
     let builder = DefaultHashBuilder::default();

--- a/dbcop_core/src/consistency/saturation/committed_read.rs
+++ b/dbcop_core/src/consistency/saturation/committed_read.rs
@@ -1,6 +1,7 @@
 //! Checks if a valid history is a committed read history.
 
 use core::hash::Hash;
+
 use hashbrown::HashMap;
 
 use crate::consistency::error::Error;

--- a/dbcop_core/src/graph/digraph.rs
+++ b/dbcop_core/src/graph/digraph.rs
@@ -158,6 +158,18 @@ where
         }
         change
     }
+
+    /// Returns all edges as a list of (source, target) pairs.
+    #[must_use]
+    pub fn to_edge_list(&self) -> Vec<(T, T)> {
+        let mut edges = Vec::new();
+        for (src, dsts) in &self.adj_map {
+            for dst in dsts {
+                edges.push((src.clone(), dst.clone()));
+            }
+        }
+        edges
+    }
 }
 
 #[cfg(test)]

--- a/dbcop_core/src/history/atomic/types.rs
+++ b/dbcop_core/src/history/atomic/types.rs
@@ -26,6 +26,7 @@ pub struct AtomicTransactionInfo<Variable> {
     pub writes: HashSet<Variable>,
 }
 
+#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TransactionId {
     pub session_id: u64,


### PR DESCRIPTION
## Summary

- Add `#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]` to `TransactionId` struct, matching the existing pattern used in `raw/types.rs`
- Add `pub fn to_edge_list(&self) -> Vec<(T, T)>` method to `DiGraph<T>` for exporting graph edges as pairs
- Apply nightly rustfmt formatting to two pre-existing files

## Verification

- `cargo build -p dbcop_core --no-default-features` passes (no_std)
- `cargo build -p dbcop_core --features serde` passes
- `cargo test -p dbcop_core` -- 73 tests pass
- `cargo clippy -p dbcop_core -- -D warnings` clean
- `cargo +nightly fmt --check --all` clean