### PR TITLE
feat(core): define Witness enum with serde support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,11 @@ dbcop/                          workspace root
 - `Consistency` enum: `CommittedRead`, `AtomicRead`, `Causal`, `Prefix`,
   `SnapshotIsolation`, `Serializable`.
 
+- `Witness` enum: returned by `check()` on success. Variants:
+  `CommitOrder(Vec<TransactionId>)` (Prefix, Serializable),
+  `SplitCommitOrder(Vec<(TransactionId, bool)>)` (SnapshotIsolation),
+  `SaturationOrder(DiGraph<TransactionId>)` (CommittedRead, AtomicRead, Causal).
+
 ## Ignored Directories
 
 `.sisyphus/` and `.omc/` are in `.gitignore`. Do NOT commit anything from those

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -24,7 +24,7 @@ workspace = true
 
 [features]
 default = [  ]
-serde   = [ "dep:serde" ]
+serde   = [ "dep:serde", "hashbrown/serde" ]
 
 [[bench]]
 name    = "consistency"

--- a/crates/core/src/consistency/error.rs
+++ b/crates/core/src/consistency/error.rs
@@ -1,4 +1,4 @@
-use ::derive_more::From;
+use derive_more::From;
 
 use crate::history::raw::error::Error as NonAtomicError;
 use crate::Consistency;

--- a/crates/core/src/consistency/mod.rs
+++ b/crates/core/src/consistency/mod.rs
@@ -13,10 +13,12 @@ use crate::history::raw::types::Session;
 pub mod error;
 pub mod linearization;
 pub mod saturation;
+pub mod witness;
 
 // Re-export submodules at the consistency level for convenience.
 pub use linearization::{constrained_linearization, prefix, serializable, snapshot_isolation};
 pub use saturation::{atomic_read, causal, committed_read, repeatable_read};
+pub use witness::Witness;
 
 /// Consistency levels supported by dbcop, ordered from weakest to strongest.
 #[derive(Debug, Copy, Clone)]

--- a/crates/core/src/consistency/saturation/atomic_read.rs
+++ b/crates/core/src/consistency/saturation/atomic_read.rs
@@ -1,6 +1,6 @@
 //! Checks if a valid history maintains atomic read.
 
-use ::core::hash::Hash;
+use core::hash::Hash;
 
 use crate::consistency::error::Error;
 use crate::history::atomic::types::AtomicTransactionHistory;

--- a/crates/core/src/consistency/saturation/causal.rs
+++ b/crates/core/src/consistency/saturation/causal.rs
@@ -1,6 +1,6 @@
 //! Checks if a valid history maintains causal consistency.
 
-use ::core::hash::Hash;
+use core::hash::Hash;
 
 use crate::consistency::error::Error;
 use crate::history::atomic::types::AtomicTransactionHistory;

--- a/crates/core/src/consistency/saturation/repeatable_read.rs
+++ b/crates/core/src/consistency/saturation/repeatable_read.rs
@@ -1,7 +1,8 @@
 //! Checks if a valid history is a atomic read history.
 
-use ::core::hash::Hash;
-use ::hashbrown::HashMap;
+use core::hash::Hash;
+
+use hashbrown::HashMap;
 
 use super::committed_read::check_committed_read;
 use crate::consistency::error::Error;

--- a/crates/core/src/consistency/witness.rs
+++ b/crates/core/src/consistency/witness.rs
@@ -1,0 +1,19 @@
+use alloc::vec::Vec;
+
+use crate::graph::digraph::DiGraph;
+use crate::history::atomic::types::TransactionId;
+
+/// Evidence that a history satisfies a given consistency level.
+#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Witness {
+    /// Commit order as a linearization of transactions.
+    /// Returned by Prefix and Serializability checkers.
+    CommitOrder(Vec<TransactionId>),
+    /// Split commit order for Snapshot Isolation.
+    /// Each transaction is split: `(TransactionId, bool)` where `bool` indicates the write half.
+    SplitCommitOrder(Vec<(TransactionId, bool)>),
+    /// Saturation-based visibility order.
+    /// Returned by Read Committed, Read Atomic, and Causal checkers.
+    SaturationOrder(DiGraph<TransactionId>),
+}

--- a/crates/core/src/graph/digraph.rs
+++ b/crates/core/src/graph/digraph.rs
@@ -4,7 +4,8 @@ use core::hash::Hash;
 
 use hashbrown::{HashMap, HashSet};
 
-#[derive(Default, Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct DiGraph<T>
 where
     T: Hash + Eq + Clone + Debug,


### PR DESCRIPTION
## Summary

- Define `Witness` enum in `crates/core/src/consistency/witness.rs` with three variants: `CommitOrder`, `SplitCommitOrder`, `SaturationOrder`
- Add `PartialEq`, `Eq`, and conditional serde derives to `DiGraph<T>` (required by `SaturationOrder` variant)
- Enable `hashbrown/serde` feature passthrough in core crate's serde feature
- Re-export `Witness` from `consistency` module
- Update AGENTS.md Key Types section

## Checks

- [x] `cargo build -p dbcop_core --no-default-features` (no_std)
- [x] `cargo build -p dbcop_core --features serde`
- [x] `cargo test -p dbcop_core` (73 tests pass)
- [x] `cargo +nightly fmt --check --all`
- [x] `cargo clippy -p dbcop_core -- -D warnings`
- [x] `taplo format --check crates/core/Cargo.toml`