### PR TITLE
refactor(core)!: change check() to return Witness on success

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,10 +133,26 @@ dbcop/                          workspace root
 - `Consistency` enum: `CommittedRead`, `AtomicRead`, `Causal`, `Prefix`,
   `SnapshotIsolation`, `Serializable`.
 
+- `check()` entry point: returns `Result<Witness, Error<Variable, Version>>`.
+  Each consistency level produces a specific `Witness` variant on success:
+  - Committed Read: `SaturationOrder(DiGraph<TransactionId>)` (committed order
+    graph)
+  - Atomic Read: `SaturationOrder(DiGraph<TransactionId>)` (visibility relation)
+  - Causal: `SaturationOrder(DiGraph<TransactionId>)` (visibility relation)
+  - Prefix: `CommitOrder(Vec<TransactionId>)` (transaction commit order)
+  - Snapshot Isolation: `SplitCommitOrder(Vec<(TransactionId, bool)>)` (split
+    read/write linearization)
+  - Serializable: `CommitOrder(Vec<TransactionId>)` (transaction commit order)
+  - Empty history: `CommitOrder(Vec::new())` (trivial witness)
+
 - `Witness` enum: returned by `check()` on success. Variants:
   `CommitOrder(Vec<TransactionId>)` (Prefix, Serializable),
   `SplitCommitOrder(Vec<(TransactionId, bool)>)` (SnapshotIsolation),
-  `SaturationOrder(DiGraph<TransactionId>)` (CommittedRead, AtomicRead, Causal).
+  `SaturationOrder(DiGraph<TransactionId>)` (Committed Read, Atomic Read,
+  Causal).
+
+- `check_committed_read()` returns `Result<DiGraph<TransactionId>, Error>` --
+  the committed order graph on success.
 
 ## Ignored Directories
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -80,7 +80,7 @@ fn verify(args: &dbcop_cli::VerifyArgs) {
             });
 
         match dbcop_core::check(history.get_data(), level) {
-            Ok(()) => println!("{filename}: PASS"),
+            Ok(_witness) => println!("{filename}: PASS"),
             Err(e) => {
                 println!("{filename}: FAIL ({e:?})");
                 any_failed = true;

--- a/crates/core/src/consistency/saturation/committed_read.rs
+++ b/crates/core/src/consistency/saturation/committed_read.rs
@@ -14,12 +14,14 @@ use crate::Consistency;
 
 /// Checks if a valid history is a committed read history.
 ///
+/// On success, returns the committed order as a [`DiGraph`] witnessing acyclicity.
+///
 /// # Errors
 ///
 /// Returns `Error::CycleInCommittedRead` if the history is not a committed read history.
 pub fn check_committed_read<Variable, Version>(
     histories: &[Session<Variable, Version>],
-) -> Result<(), Error<Variable, Version>>
+) -> Result<DiGraph<TransactionId>, Error<Variable, Version>>
 where
     Variable: Eq + Hash + Clone,
     Version: Eq + Hash + Clone,
@@ -134,7 +136,7 @@ where
     committed_order
         .topological_sort()
         .is_some()
-        .then_some(())
+        .then_some(committed_order)
         .ok_or(Error::Invalid(Consistency::CommittedRead))
 }
 

--- a/crates/core/tests/paper_causal_prefix.rs
+++ b/crates/core/tests/paper_causal_prefix.rs
@@ -19,6 +19,7 @@
 //!     where a CC-valid history fails: SnapshotIsolation, not Prefix.
 
 use dbcop_core::consistency::error::Error;
+use dbcop_core::consistency::Witness;
 use dbcop_core::history::raw::types::{Event, Session, Transaction};
 use dbcop_core::{check, Consistency};
 
@@ -36,11 +37,11 @@ fn r(var: &'static str, ver: u64) -> Event<&'static str, u64> {
     Event::read(var, ver)
 }
 
-fn check_causal(h: &[Session<&'static str, u64>]) -> Result<(), Error<&'static str, u64>> {
+fn check_causal(h: &[Session<&'static str, u64>]) -> Result<Witness, Error<&'static str, u64>> {
     check(h, Consistency::Causal)
 }
 
-fn check_prefix(h: &[Session<&'static str, u64>]) -> Result<(), Error<&'static str, u64>> {
+fn check_prefix(h: &[Session<&'static str, u64>]) -> Result<Witness, Error<&'static str, u64>> {
     check(h, Consistency::Prefix)
 }
 


### PR DESCRIPTION
## Summary

- **Breaking change**: `check()` now returns `Result<Witness, Error<Variable, Version>>` instead of `Result<(), Error<Variable, Version>>`
- `check_committed_read()` returns `Result<DiGraph<TransactionId>, Error>` (the committed order graph) instead of `Result<(), Error>`
- Each consistency level returns the correct `Witness` variant:
  - Committed Read / Atomic Read / Causal: `SaturationOrder(DiGraph<TransactionId>)`
  - Prefix / Serializable: `CommitOrder(Vec<TransactionId>)`
  - Snapshot Isolation: `SplitCommitOrder(Vec<(TransactionId, bool)>)`
  - Empty history: `CommitOrder(Vec::new())`

## Changes

- `crates/core/src/consistency/mod.rs`: Changed `check()` return type, wired each level to its `Witness` variant
- `crates/core/src/consistency/saturation/committed_read.rs`: Changed `check_committed_read()` to return `DiGraph<TransactionId>` on success
- `crates/cli/src/main.rs`: Updated pattern match from `Ok(())` to `Ok(_witness)`
- `crates/core/tests/paper_causal_prefix.rs`: Updated helper return types
- `AGENTS.md`: Documented `check()` return type and per-level witness mapping

## Verification

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (92 tests pass)
- [x] `cargo +nightly fmt --check --all`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo build -p dbcop_core --no-default-features` (no_std)