### PR TITLE
feat(core): enrich Error with conflicting transaction pair

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,9 @@ dbcop/                          workspace root
 
 - `DiGraph<T>` -- directed graph with adjacency map. Key methods:
   `add_edge(from, to)`, `add_vertex(v)`, `closure()`, `topological_sort()`,
-  `union(other)`, `is_acyclic()`, `to_edge_list()`.
+  `union(other)`, `is_acyclic()`, `to_edge_list()`,
+  `find_cycle_edge() -> Option<(T, T)>` (returns an edge on a cycle via Kahn's
+  algorithm).
 
 - `AtomicTransactionPO` -- per-history partial order. Holds:
   `session_order: DiGraph<TransactionId>`,
@@ -150,6 +152,15 @@ dbcop/                          workspace root
   `SplitCommitOrder(Vec<(TransactionId, bool)>)` (SnapshotIsolation),
   `SaturationOrder(DiGraph<TransactionId>)` (Committed Read, Atomic Read,
   Causal).
+
+- `Error<Variable, Version>` enum: returned by `check()` on failure. Variants:
+  `NonAtomic(NonAtomicError)` (structural issue like uncommitted writes),
+  `Invalid(Consistency)` (violates consistency level, no specific pair known --
+  used by linearization failures),
+  `Cycle { level: Consistency, a:
+  TransactionId, b: TransactionId }` (cycle
+  detected with a conflicting edge pair -- used by saturation checkers:
+  Committed Read, Atomic Read, Causal).
 
 - `check_committed_read()` returns `Result<DiGraph<TransactionId>, Error>` --
   the committed order graph on success.

--- a/crates/core/src/consistency/error.rs
+++ b/crates/core/src/consistency/error.rs
@@ -1,13 +1,22 @@
 use derive_more::From;
 
+use crate::history::atomic::types::TransactionId;
 use crate::history::raw::error::Error as NonAtomicError;
 use crate::Consistency;
 
 /// Error returned when a history fails a consistency check.
+#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
 #[derive(Debug, From)]
 pub enum Error<Variable, Version> {
     /// The history has a structural issue (e.g. uncommitted writes read by others).
     NonAtomic(NonAtomicError<Variable, Version>),
     /// The history violates the specified consistency level.
     Invalid(Consistency),
+    /// A cycle was detected in the partial order for the given consistency level.
+    /// The two transaction IDs are an example of a conflicting edge in the cycle.
+    Cycle {
+        level: Consistency,
+        a: TransactionId,
+        b: TransactionId,
+    },
 }

--- a/crates/core/src/consistency/mod.rs
+++ b/crates/core/src/consistency/mod.rs
@@ -22,6 +22,7 @@ pub use saturation::{atomic_read, causal, committed_read, repeatable_read};
 pub use witness::Witness;
 
 /// Consistency levels supported by dbcop, ordered from weakest to strongest.
+#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
 #[derive(Debug, Copy, Clone)]
 pub enum Consistency {
     /// No transaction reads from an aborted or uncommitted write.

--- a/crates/core/src/consistency/saturation/atomic_read.rs
+++ b/crates/core/src/consistency/saturation/atomic_read.rs
@@ -30,10 +30,17 @@ where
         atomic_history.vis_includes(ww_x);
     }
 
-    atomic_history
-        .has_valid_visibility()
-        .then_some(atomic_history)
-        .ok_or(Error::Invalid(Consistency::AtomicRead))
+    if atomic_history.has_valid_visibility() {
+        Ok(atomic_history)
+    } else if let Some((a, b)) = atomic_history.visibility_relation.find_cycle_edge() {
+        Err(Error::Cycle {
+            level: Consistency::AtomicRead,
+            a,
+            b,
+        })
+    } else {
+        Err(Error::Invalid(Consistency::AtomicRead))
+    }
 }
 
 #[cfg(test)]
@@ -58,7 +65,10 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(Error::Invalid(Consistency::AtomicRead))
+            Err(Error::Cycle {
+                level: Consistency::AtomicRead,
+                ..
+            })
         ));
     }
 }

--- a/crates/core/src/history/raw/error.rs
+++ b/crates/core/src/history/raw/error.rs
@@ -2,6 +2,7 @@ use super::types::Event;
 use crate::history::raw::types::EventId;
 
 /// Error converting a raw history to an atomic transactional history
+#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
 #[derive(Debug)]
 pub enum Error<Variable, Version> {
     /// Reads an absent value

--- a/crates/core/src/history/raw/types.rs
+++ b/crates/core/src/history/raw/types.rs
@@ -125,6 +125,7 @@ impl<Variable, Version> Transaction<Variable, Version> {
 pub type Session<Variable, Version> = Vec<Transaction<Variable, Version>>;
 
 /// Uniquely identifies an event within a history by session, transaction, and position.
+#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EventId {
     pub session_id: u64,

--- a/crates/core/tests/consistency.rs
+++ b/crates/core/tests/consistency.rs
@@ -80,7 +80,13 @@ fn committed_read_violation() {
 
     let result = check_committed_read(&h);
     assert!(
-        matches!(result, Err(Error::Invalid(Consistency::CommittedRead))),
+        matches!(
+            result,
+            Err(Error::Cycle {
+                level: Consistency::CommittedRead,
+                ..
+            })
+        ),
         "expected committed read violation, got {result:?}",
     );
 }
@@ -135,7 +141,13 @@ fn atomic_read_violation() {
 
     let result = check_atomic_read(&h);
     assert!(
-        matches!(result, Err(Error::Invalid(Consistency::AtomicRead))),
+        matches!(
+            result,
+            Err(Error::Cycle {
+                level: Consistency::AtomicRead,
+                ..
+            })
+        ),
         "expected atomic read violation, got {result:?}",
     );
 }
@@ -187,7 +199,10 @@ fn causal_violation() {
     assert!(
         matches!(
             check_causal_read(&h),
-            Err(Error::Invalid(Consistency::Causal))
+            Err(Error::Cycle {
+                level: Consistency::Causal,
+                ..
+            })
         ),
         "should violate causal",
     );

--- a/crates/core/tests/paper_causal_prefix.rs
+++ b/crates/core/tests/paper_causal_prefix.rs
@@ -108,7 +108,13 @@ fn cc_violation_cycle() {
         "should pass Atomic Read"
     );
     assert!(
-        matches!(check_causal(&h), Err(Error::Invalid(Consistency::Causal))),
+        matches!(
+            check_causal(&h),
+            Err(Error::Cycle {
+                level: Consistency::Causal,
+                ..
+            })
+        ),
         "must fail CC due to causal visibility cycle"
     );
 }
@@ -155,7 +161,13 @@ fn cc_violation_ww_conflict() {
     ];
 
     assert!(
-        matches!(check_causal(&h), Err(Error::Invalid(Consistency::Causal))),
+        matches!(
+            check_causal(&h),
+            Err(Error::Cycle {
+                level: Consistency::Causal,
+                ..
+            })
+        ),
         "6-session ww-conflict must fail CC"
     );
 }

--- a/crates/core/tests/paper_polynomial.rs
+++ b/crates/core/tests/paper_polynomial.rs
@@ -83,7 +83,13 @@ fn rc_violation_committed_order_cycle() {
     };
     let result = check_committed_read(&h);
     assert!(
-        matches!(result, Err(Error::Invalid(Consistency::CommittedRead))),
+        matches!(
+            result,
+            Err(Error::Cycle {
+                level: Consistency::CommittedRead,
+                ..
+            })
+        ),
         "expected RC violation, got {result:?}",
     );
 }
@@ -240,7 +246,13 @@ fn ra_violation_stale_read_after_newer() {
     };
     let result = check_atomic_read(&h);
     assert!(
-        matches!(result, Err(Error::Invalid(Consistency::AtomicRead))),
+        matches!(
+            result,
+            Err(Error::Cycle {
+                level: Consistency::AtomicRead,
+                ..
+            })
+        ),
         "expected AtomicRead violation, got {result:?}",
     );
 }


### PR DESCRIPTION
## Summary

- Add `Error::Cycle { level, a, b }` variant carrying conflicting `TransactionId` pair when saturation checkers detect a cycle
- Add `DiGraph::find_cycle_edge()` method using Kahn's algorithm to extract an edge on a cycle in O(V+E)
- All three saturation checkers (Committed Read, Atomic Read, Causal) now emit `Error::Cycle` instead of `Error::Invalid` when a cycle is found
- `Error::Invalid(Consistency)` preserved for linearization failures where no specific pair is known
- Serde gates added to `Error`, `Consistency`, `NonAtomicError`, and `EventId`
- AGENTS.md updated with new `Error` variant and `find_cycle_edge()` documentation