### PR TITLE
feat(cli): add --verbose and --json flags for witness and error display

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,28 @@ dbcop/                          workspace root
   rustfmt.toml                   nightly rustfmt config
 ```
 
+## CLI Usage
+
+The `dbcop` binary has two subcommands: `generate` and `verify`.
+
+### Verify Flags
+
+- `--input-dir <DIR>` -- directory containing history JSON files (required)
+- `--consistency <LEVEL>` -- consistency level to check (required). Values:
+  `committed-read`, `atomic-read`, `causal`, `prefix`, `snapshot-isolation`,
+  `serializable`.
+- `--verbose` -- on PASS prints witness details (Debug format), on FAIL prints
+  full error details. Output: `{filename}: PASS\n  witness: {witness:?}` or
+  `{filename}: FAIL\n  error: {error:?}`.
+- `--json` -- outputs one JSON object per file to stdout. On PASS:
+  `{"file": "...", "ok": true, "witness": {...}}`. On FAIL:
+  `{"file": "...", "ok": false, "error": {...}}`. Witness and error are
+  serialized via serde (requires the `serde` feature on `dbcop_core`, which the
+  CLI enables by default).
+
+Default output (no flags): `{filename}: PASS` or `{filename}: FAIL ({error:?})`
+on a single line.
+
 ## Key Types
 
 - `TransactionId { session_id: u64, session_height: u64 }` Default value (0, 0)

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -52,6 +52,12 @@ pub struct VerifyArgs {
     /// Consistency level to check
     #[arg(long)]
     pub consistency: ConsistencyLevel,
+    /// Print witness details on PASS and full error details on FAIL
+    #[arg(long)]
+    pub verbose: bool,
+    /// Output results as JSON (one object per file)
+    #[arg(long)]
+    pub json: bool,
 }
 
 #[derive(Debug, Clone, ValueEnum)]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -80,10 +80,36 @@ fn verify(args: &dbcop_cli::VerifyArgs) {
             });
 
         match dbcop_core::check(history.get_data(), level) {
-            Ok(_witness) => println!("{filename}: PASS"),
+            Ok(witness) => {
+                if args.json {
+                    let result = serde_json::json!({
+                        "file": filename,
+                        "ok": true,
+                        "witness": witness,
+                    });
+                    println!("{}", serde_json::to_string(&result).unwrap());
+                } else if args.verbose {
+                    println!("{filename}: PASS");
+                    println!("  witness: {witness:?}");
+                } else {
+                    println!("{filename}: PASS");
+                }
+            }
             Err(e) => {
-                println!("{filename}: FAIL ({e:?})");
                 any_failed = true;
+                if args.json {
+                    let result = serde_json::json!({
+                        "file": filename,
+                        "ok": false,
+                        "error": e,
+                    });
+                    println!("{}", serde_json::to_string(&result).unwrap());
+                } else if args.verbose {
+                    println!("{filename}: FAIL");
+                    println!("  error: {e:?}");
+                } else {
+                    println!("{filename}: FAIL ({e:?})");
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- Add `--verbose` and `--json` flags to `VerifyArgs` in `crates/cli/src/lib.rs`
- `--verbose`: on PASS prints `witness: {witness:?}`, on FAIL prints `error: {error:?}` (human-readable Debug format)
- `--json`: outputs one JSON object per file to stdout with `file`, `ok`, and `witness`/`error` fields (uses serde serialization)
- Default output unchanged: `{filename}: PASS` or `{filename}: FAIL ({error:?})`
- Update `AGENTS.md` with CLI Usage section documenting verify flags