### PR TITLE
feat(wasm): return structured JSON from check_consistency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,28 @@ The `dbcop` binary has two subcommands: `generate` and `verify`.
 Default output (no flags): `{filename}: PASS` or `{filename}: FAIL ({error:?})`
 on a single line.
 
+## WASM Usage
+
+The `dbcop_wasm` crate exposes a single function via `wasm_bindgen`:
+
+`check_consistency(history_json: &str, level: &str) -> String`
+
+- `history_json`: JSON-encoded array of sessions (same format as CLI input
+  files).
+- `level`: one of `committed-read`, `atomic-read`, `causal`, `prefix`,
+  `snapshot-isolation`, `serializable`.
+
+Returns a JSON string with the following schema:
+
+- On success: `{"ok": true, "witness": {...}}` -- witness is the serialized
+  `Witness` enum (same structure as CLI `--json` output).
+- On check failure: `{"ok": false, "error": {...}}` -- error is the serialized
+  `Error` enum.
+- On invalid consistency level:
+  `{"ok": false, "error": "unknown consistency level"}`.
+- On malformed JSON input:
+  `{"ok": false, "error": "<parse error description>"}`.
+
 ## Key Types
 
 - `TransactionId { session_id: u64, session_height: u64 }` Default value (0, 0)

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -6,6 +6,7 @@
 
 extern crate alloc;
 
+use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
 use dbcop_core::history::raw::types::Session;
@@ -24,16 +25,28 @@ fn parse_level(level: &str) -> Option<Consistency> {
     }
 }
 
+/// Check whether a history (as JSON) satisfies the given consistency level.
+///
+/// Returns a JSON string:
+/// - On success: `{"ok":true,"witness":{...}}`
+/// - On failure: `{"ok":false,"error":{...}}`
+/// - On invalid input: `{"ok":false,"error":"<description>"}`
 #[must_use]
 #[wasm_bindgen]
-pub fn check_consistency(history_json: &str, level: &str) -> bool {
+pub fn check_consistency(history_json: &str, level: &str) -> String {
     let Some(consistency) = parse_level(level) else {
-        return false;
+        return serde_json::json!({"ok": false, "error": "unknown consistency level"}).to_string();
     };
 
-    let Ok(sessions) = serde_json::from_str::<Vec<Session<u64, u64>>>(history_json) else {
-        return false;
+    let sessions = match serde_json::from_str::<Vec<Session<u64, u64>>>(history_json) {
+        Ok(s) => s,
+        Err(e) => {
+            return serde_json::json!({"ok": false, "error": e.to_string()}).to_string();
+        }
     };
 
-    dbcop_core::check(&sessions, consistency).is_ok()
+    match dbcop_core::check(&sessions, consistency) {
+        Ok(witness) => serde_json::json!({"ok": true, "witness": witness}).to_string(),
+        Err(error) => serde_json::json!({"ok": false, "error": error}).to_string(),
+    }
 }


### PR DESCRIPTION
## Summary

- Change `check_consistency` in `dbcop_wasm` to return a JSON `String` instead of `bool`
- On success: `{"ok": true, "witness": {...}}` with serialized `Witness` enum
- On failure: `{"ok": false, "error": {...}}` with serialized `Error` enum
- On invalid input: `{"ok": false, "error": "<description>"}` with parse error or unknown level message
- Document WASM return type schema in AGENTS.md

## Changes

- `crates/wasm/src/lib.rs`: Return `String` with structured JSON via `serde_json::json!`
- `AGENTS.md`: Add WASM Usage section documenting `check_consistency` API and JSON schema