### PR TITLE
feat(sat): extract witness from SAT solver model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,6 +187,16 @@ on a single line.
 - `check_committed_read()` returns `Result<DiGraph<TransactionId>, Error>` --
   the committed order graph on success.
 
+- SAT checker functions (`dbcop_sat`): `check_serializable()`, `check_prefix()`,
+  `check_snapshot_isolation()` all return `Result<Witness, Error>`. On
+  satisfiable: the commit order is extracted from the SAT model by counting
+  predecessors (for each vertex `u`, its position is the number of other
+  vertices `w` where `before(w, u)` is true in the satisfying assignment).
+  Serializable returns `Witness::CommitOrder`, Prefix returns
+  `Witness::CommitOrder` (write-phase vertices only), Snapshot Isolation returns
+  `Witness::SplitCommitOrder` (full split-phase ordering). On unsatisfiable:
+  returns `Error::Invalid(Consistency::*)`.
+
 ## Ignored Directories
 
 `.sisyphus/` and `.omc/` are in `.gitignore`. Do NOT commit anything from those


### PR DESCRIPTION
## Summary

- SAT checker functions (`check_serializable`, `check_prefix`, `check_snapshot_isolation`) now return `Result<Witness, Error>` instead of `Result<(), Error>`
- On SAT: extracts commit order from the model by counting predecessors for each vertex (position = number of vertices `w` where `before(w, u)` is true)
- Serializable and Prefix return `Witness::CommitOrder`, Snapshot Isolation returns `Witness::SplitCommitOrder`
- On UNSAT: returns `Err(Error::Invalid(Consistency::*))`
- All 92 workspace tests pass, clippy clean, fmt clean
- AGENTS.md updated with SAT witness extraction documentation