### PR TITLE
perf(core): incremental transitive closure in saturation loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -244,6 +244,11 @@ memory.
   for biconnected component decomposition (Theorem 5.2) to reduce NP-complete
   checker complexity by solving independent sub-histories separately.
 
+- Incremental transitive closure (`digraph.rs`): `incremental_closure()` extends
+  an existing closed graph with new edges using BFS ancestor/descendant
+  cross-product. Used in causal checker to avoid O(V\*(V+E)) full closure on
+  each saturation iteration.
+
 ## Testing
 
 - Unit tests: `#[cfg(test)] mod tests` blocks inside `src/` files.


### PR DESCRIPTION
## Summary

- Add `incremental_closure()` to `DiGraph<T>` that extends an already transitively-closed graph with new edges using BFS ancestor/descendant cross-product
- Wire it into the causal saturation loop (`causal.rs`) to replace full `closure()` recomputation on each iteration: initial full closure once, then incremental per iteration
- Add 3 unit tests: incremental from empty matches full closure, extends existing closed graph, no-change case
- Update AGENTS.md Performance Decisions section