### PR TITLE
feat(core,cli): add tracing instrumentation with RUST_LOG env support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,20 @@ The `dbcop` binary has two subcommands: `generate` and `verify`.
 Default output (no flags): `{filename}: PASS` or `{filename}: FAIL ({error:?})`
 on a single line.
 
+### Debugging with RUST_LOG
+
+The CLI initializes a `tracing-subscriber` that reads `RUST_LOG`. Use this to
+see detailed consistency checking logs:
+
+```bash
+RUST_LOG=debug dbcop verify --input-dir ./histories --consistency serializable
+RUST_LOG=dbcop_core=trace dbcop verify --input-dir ./histories --consistency causal
+```
+
+Log levels: `debug` shows checker entry/exit and results, `trace` shows
+per-iteration saturation details. The `dbcop_core` crate uses `tracing::debug!`
+and `tracing::trace!` for instrumentation.
+
 ## WASM Usage
 
 The `dbcop_wasm` crate exposes a single function via `wasm_bindgen`:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,18 +29,19 @@ readme = "README.md"
 dbcop_core    = { version = "0.2.0", path = "crates/core" }
 dbcop_testgen = { version = "0.2.0", path = "crates/testgen" }
 
-clap          = { version = "4.5", features = [ "derive" ] }
-serde_json    = { version = "1.0", default-features = false }
-petgraph      = { version = "0.8" }
-tracing       = { version = "0.1" }
-serde         = { version = "1.0" }
-hashbrown     = { version = "0.16" }
-wasm-bindgen  = { version = "=0.2.109" }
-typed-builder = { version = "0.23" }
-chrono        = { version = "0.4" }
-rand          = { version = "0.9" }
-rayon         = { version = "1.10" }
-derive_more   = { version = "2.1", default-features = false, features = [ "from" ] }
+clap               = { version = "4.5", features = [ "derive" ] }
+serde_json         = { version = "1.0", default-features = false }
+petgraph           = { version = "0.8" }
+tracing            = { version = "0.1" }
+tracing-subscriber = { version = "0.3", default-features = false, features = [ "fmt", "env-filter" ] }
+serde              = { version = "1.0" }
+hashbrown          = { version = "0.16" }
+wasm-bindgen       = { version = "=0.2.109" }
+typed-builder      = { version = "0.23" }
+chrono             = { version = "0.4" }
+rand               = { version = "0.9" }
+rayon              = { version = "1.10" }
+derive_more        = { version = "2.1", default-features = false, features = [ "from" ] }
 
 [workspace.lints.rust]
 unused_qualifications = "warn"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -18,8 +18,9 @@ path = "src/main.rs"
 dbcop_core    = { workspace = true, features = [ "serde" ] }
 dbcop_testgen = { workspace = true }
 
-clap       = { workspace = true }
-serde_json = { workspace = true, features = [ "std" ] }
+clap               = { workspace = true }
+serde_json         = { workspace = true, features = [ "std" ] }
+tracing-subscriber = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2,8 +2,13 @@ use std::{fs, process};
 
 use clap::Parser;
 use dbcop_cli::{App, Command};
+use tracing_subscriber::EnvFilter;
 
 fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
+
     let app = App::parse();
     match &app.command {
         Command::Generate(args) => generate(args),

--- a/crates/core/src/consistency/mod.rs
+++ b/crates/core/src/consistency/mod.rs
@@ -55,9 +55,12 @@ where
     Variable: Eq + Hash + Clone + Ord,
     Version: Eq + Hash + Clone,
 {
+    tracing::debug!(sessions = sessions.len(), ?level, "checking consistency");
+
     // Trivially consistent: no sessions or all sessions empty
     #[allow(clippy::redundant_closure_for_method_calls)]
     if sessions.is_empty() || sessions.iter().all(|s| s.is_empty()) {
+        tracing::debug!("trivially consistent: no sessions or all empty");
         return Ok(Witness::CommitOrder(Vec::new()));
     }
 

--- a/crates/core/src/consistency/saturation/atomic_read.rs
+++ b/crates/core/src/consistency/saturation/atomic_read.rs
@@ -19,6 +19,11 @@ where
     Variable: Eq + Hash + Clone,
     Version: Eq + Hash + Clone,
 {
+    tracing::debug!(
+        sessions = histories.len(),
+        "atomic read check: building partial order"
+    );
+
     let mut atomic_history =
         AtomicTransactionPO::from(AtomicTransactionHistory::try_from(histories)?);
 
@@ -26,19 +31,27 @@ where
 
     let ww_rel = atomic_history.causal_ww();
 
+    tracing::trace!(
+        variables = ww_rel.len(),
+        "atomic read check: applying write-write edges"
+    );
+
     for ww_x in ww_rel.values() {
         atomic_history.vis_includes(ww_x);
     }
 
     if atomic_history.has_valid_visibility() {
+        tracing::debug!("atomic read check: passed");
         Ok(atomic_history)
     } else if let Some((a, b)) = atomic_history.visibility_relation.find_cycle_edge() {
+        tracing::debug!(?a, ?b, "atomic read check: cycle detected");
         Err(Error::Cycle {
             level: Consistency::AtomicRead,
             a,
             b,
         })
     } else {
+        tracing::debug!("atomic read check: failed (no cycle edge found)");
         Err(Error::Invalid(Consistency::AtomicRead))
     }
 }

--- a/crates/core/src/consistency/saturation/committed_read.rs
+++ b/crates/core/src/consistency/saturation/committed_read.rs
@@ -19,6 +19,7 @@ use crate::Consistency;
 /// # Errors
 ///
 /// Returns `Error::CycleInCommittedRead` if the history is not a committed read history.
+#[allow(clippy::too_many_lines)]
 pub fn check_committed_read<Variable, Version>(
     histories: &[Session<Variable, Version>],
 ) -> Result<DiGraph<TransactionId>, Error<Variable, Version>>


### PR DESCRIPTION
## Summary

- Add `tracing::debug!` and `tracing::trace!` instrumentation to `dbcop_core` consistency checkers (`check()`, committed read, atomic read, causal saturation loop)
- Add `tracing-subscriber` with `env-filter` to `dbcop_cli` for RUST_LOG-based log filtering
- Update AGENTS.md with debugging instructions

## Usage

```bash
RUST_LOG=debug dbcop verify --input-dir ./histories --consistency serializable
RUST_LOG=dbcop_core=trace dbcop verify --input-dir ./histories --consistency causal
```

## Verification

- `cargo build --workspace` passes
- `cargo test --workspace` passes (98 tests)
- `cargo build -p dbcop_core --no-default-features` passes (no_std check)
- `cargo +nightly fmt --all` clean
- `taplo format --check` clean