### PR TITLE
docs(core): document saturation checkers and linearization solvers

### DIFF
--- a/crates/core/src/consistency/linearization/constrained_linearization.rs
+++ b/crates/core/src/consistency/linearization/constrained_linearization.rs
@@ -1,3 +1,61 @@
+//! Constrained linearization framework for NP-complete consistency checks.
+//!
+//! This module provides the [`ConstrainedLinearizationSolver`] trait and
+//! its DFS-based search engine. Consistency levels that are NP-complete
+//! to verify (Prefix Consistency, Snapshot Isolation, Serializability)
+//! reduce to finding a valid topological ordering of a directed graph
+//! that satisfies additional domain-specific constraints.
+//!
+//! # How it works
+//!
+//! The solver performs a depth-first search over all possible topological
+//! orderings of the visibility graph, pruning branches that violate the
+//! consistency-specific constraints:
+//!
+//! 1. Compute in-degree (`active_parent` count) for every vertex.
+//! 2. Seed the frontier with all vertices having zero in-degree.
+//! 3. At each step, try each frontier vertex:
+//!    a. Check `allow_next()` -- does this vertex satisfy the
+//!    consistency constraint at this position?
+//!    b. If yes, place it: update the frontier, call
+//!    `forward_book_keeping()`, and recurse.
+//!    c. If the recursion fails, call `backtrack_book_keeping()` to
+//!    undo, restore the frontier, and try the next candidate.
+//! 4. If all vertices are placed, return the linearization.
+//!    If all candidates are exhausted, return `None`.
+//!
+//! # Memoization
+//!
+//! To avoid re-exploring equivalent frontier states reached via
+//! different orderings, the solver maintains a `seen` set of Zobrist
+//! hashes. Each frontier state is hashed by XOR-ing per-vertex random
+//! u128 values, giving O(1) hash updates on vertex add/remove. This
+//! replaces a naive `HashSet<BTreeSet<Vertex>>` approach that would
+//! cost O(T log T) per state.
+//!
+//! # Trait contract
+//!
+//! Implementors define:
+//!
+//! - [`Vertex`] -- the type of graph nodes (e.g. `TransactionId` or
+//!   `(TransactionId, bool)` for split-phase solvers).
+//! - [`get_root`] -- the root vertex (typically `TransactionId::default()`).
+//! - [`children_of`] -- successors in the visibility graph.
+//! - [`vertices`] -- all vertices in the graph.
+//! - [`allow_next`] -- the consistency-specific filter.
+//! - [`forward_book_keeping`] -- update solver state when a vertex is
+//!   placed in the linearization.
+//! - [`backtrack_book_keeping`] -- undo solver state when a vertex is
+//!   removed during backtracking.
+//!
+//! [`Vertex`]: ConstrainedLinearizationSolver::Vertex
+//! [`get_root`]: ConstrainedLinearizationSolver::get_root
+//! [`children_of`]: ConstrainedLinearizationSolver::children_of
+//! [`vertices`]: ConstrainedLinearizationSolver::vertices
+//! [`allow_next`]: ConstrainedLinearizationSolver::allow_next
+//! [`forward_book_keeping`]: ConstrainedLinearizationSolver::forward_book_keeping
+//! [`backtrack_book_keeping`]: ConstrainedLinearizationSolver::backtrack_book_keeping
+
 use alloc::collections::vec_deque::VecDeque;
 use alloc::vec::Vec;
 use core::fmt::Debug;
@@ -5,7 +63,12 @@ use core::hash::Hash;
 
 use hashbrown::{HashMap, HashSet};
 
-// Zobrist hash: XOR two u64 hashes with different seeds -> u128
+/// Compute a Zobrist hash value for a vertex.
+///
+/// Produces a u128 by hashing the vertex with two different seeds and
+/// combining the results. Used for O(1) incremental frontier hashing:
+/// XOR-ing in a vertex when it enters the frontier and XOR-ing it out
+/// when it leaves.
 fn zobrist_value<T: Hash>(v: &T) -> u128 {
     use core::hash::{BuildHasher, Hasher};
 
@@ -25,20 +88,78 @@ fn zobrist_value<T: Hash>(v: &T) -> u128 {
     (u128::from(hi) << 64) | u128::from(lo)
 }
 
+/// Trait for consistency-specific linearization solvers.
+///
+/// Implementors define the graph structure and constraints for a
+/// particular consistency level. The default [`do_dfs`] and
+/// [`get_linearization`] methods provide the DFS search engine with
+/// Zobrist-hash memoization.
+///
+/// [`do_dfs`]: ConstrainedLinearizationSolver::do_dfs
+/// [`get_linearization`]: ConstrainedLinearizationSolver::get_linearization
 pub trait ConstrainedLinearizationSolver {
+    /// The type of vertices in the linearization graph.
+    ///
+    /// For Serializability this is `TransactionId`. For Prefix
+    /// Consistency and Snapshot Isolation this is
+    /// `(TransactionId, bool)` where the bool distinguishes the read
+    /// phase (`false`) from the write phase (`true`).
     type Vertex: Hash + Ord + Eq + Clone + Debug;
 
+    /// Return the root vertex of the visibility graph.
+    ///
+    /// This is the starting point of the linearization, typically
+    /// `TransactionId::default()` (the implicit initial transaction).
     fn get_root(&self) -> Self::Vertex;
 
+    /// Return the successors of `source` in the visibility graph.
+    ///
+    /// Returns `None` if `source` has no outgoing edges in the
+    /// adjacency map, or `Some(vec)` with the list of successors.
+    /// These successors become candidates for the frontier once all
+    /// their parents have been placed.
     fn children_of(&self, source: &Self::Vertex) -> Option<Vec<Self::Vertex>>;
 
+    /// Test whether vertex `v` may be placed next in the linearization.
+    ///
+    /// This is the consistency-specific constraint filter. For example,
+    /// the Serializability solver checks that placing `v` does not
+    /// conflict with any outstanding active writes.
     fn allow_next(&self, linearization: &[Self::Vertex], v: &Self::Vertex) -> bool;
 
+    /// Return all vertices in the graph.
+    ///
+    /// Used during initialization to compute in-degrees and seed the
+    /// frontier.
     fn vertices(&self) -> Vec<Self::Vertex>;
 
+    /// Update solver state after placing a vertex in the linearization.
+    ///
+    /// Called immediately after a vertex is appended to the
+    /// linearization during forward exploration. Implementations
+    /// typically update `active_write` and `active_variable` tracking
+    /// maps.
     fn forward_book_keeping(&mut self, linearization: &[Self::Vertex]);
+
+    /// Undo solver state after removing a vertex during backtracking.
+    ///
+    /// Called when the DFS backtracks past a vertex. Must exactly
+    /// reverse the effects of [`forward_book_keeping`] to restore the
+    /// solver to its previous state.
+    ///
+    /// [`forward_book_keeping`]: ConstrainedLinearizationSolver::forward_book_keeping
     fn backtrack_book_keeping(&mut self, linearization: &[Self::Vertex]);
 
+    /// Recursive DFS step with Zobrist memoization.
+    ///
+    /// Tries each vertex in `non_det_choices` (the current frontier).
+    /// For each candidate that passes `allow_next`, places it, updates
+    /// the frontier, and recurses. On failure, backtracks and restores
+    /// state. Returns `true` if a complete linearization is found.
+    ///
+    /// The `seen` set and `frontier_hash` implement Zobrist memoization:
+    /// if the current frontier hash has been seen before, this branch is
+    /// pruned immediately.
     fn do_dfs(
         &mut self,
         non_det_choices: &mut VecDeque<Self::Vertex>,
@@ -109,6 +230,16 @@ pub trait ConstrainedLinearizationSolver {
         }
     }
 
+    /// Search for a valid constrained linearization.
+    ///
+    /// Initializes the in-degree map and frontier, then runs [`do_dfs`]
+    /// to find a topological ordering that satisfies all constraints.
+    ///
+    /// Returns `Some(linearization)` if a valid ordering exists, or
+    /// `None` if no valid linearization can be found (indicating the
+    /// history violates the target consistency level).
+    ///
+    /// [`do_dfs`]: ConstrainedLinearizationSolver::do_dfs
     fn get_linearization(&mut self) -> Option<Vec<Self::Vertex>> {
         let mut non_det_choices: VecDeque<Self::Vertex> = VecDeque::default();
         let mut active_parent: HashMap<Self::Vertex, usize> = HashMap::default();

--- a/crates/core/src/consistency/linearization/prefix.rs
+++ b/crates/core/src/consistency/linearization/prefix.rs
@@ -1,3 +1,46 @@
+//! Prefix Consistency linearization solver.
+//!
+//! Prefix Consistency strengthens Causal Consistency by requiring a total
+//! commit order on all transactions such that every transaction's visible
+//! set is a prefix of this order. In other words, if T1 precedes T2 in
+//! commit order, then everything visible to T1 is also visible to T2.
+//!
+//! # Approach
+//!
+//! This module implements a [`ConstrainedLinearizationSolver`] that
+//! searches for a valid commit order via depth-first search with
+//! backtracking. Each transaction is split into two vertices:
+//!
+//! - `(TransactionId, false)` -- the *read phase*, representing the point
+//!   at which the transaction's snapshot is taken.
+//! - `(TransactionId, true)` -- the *write phase*, representing the point
+//!   at which the transaction's writes become visible.
+//!
+//! The solver enforces that when a write phase is placed in the
+//! linearization, no other transaction has outstanding readers of the
+//! same variable (the `active_write` constraint). This ensures the
+//! prefix property: every reader has already observed this write or a
+//! later one.
+//!
+//! # Data flow
+//!
+//! ```text
+//! AtomicTransactionPO (from causal check)
+//!     -> PrefixConsistencySolver -> get_linearization() via DFS
+//!     -> Some(Vec<(TransactionId, bool)>) or None
+//!     -> filter write-phase vertices -> Witness::CommitOrder
+//! ```
+//!
+//! # Witness
+//!
+//! On success, the caller extracts only the write-phase vertices from the
+//! linearization to produce a `Witness::CommitOrder(Vec<TransactionId>)`.
+//!
+//! # Reference
+//!
+//! Implements the constrained linearization search described in
+//! Theorem 4.8 of Biswas and Enea (2019).
+
 use alloc::vec::Vec;
 use core::hash::Hash;
 
@@ -7,6 +50,13 @@ use crate::consistency::constrained_linearization::ConstrainedLinearizationSolve
 use crate::history::atomic::types::TransactionId;
 use crate::history::atomic::AtomicTransactionPO;
 
+/// Linearization solver for Prefix Consistency.
+///
+/// Wraps an [`AtomicTransactionPO`] and tracks `active_write` -- a map
+/// from each variable to the set of transactions that still have
+/// unresolved readers for that variable's current write. A write phase
+/// is only allowed when all of its variables have at most one active
+/// writer (itself).
 #[derive(Debug)]
 pub struct PrefixConsistencySolver<Variable>
 where


### PR DESCRIPTION
## Summary

- Add comprehensive Rustdoc (`//!` and `///`) documentation for all 7 consistency checker modules in `dbcop_core`
- Saturation checkers: `committed_read.rs`, `atomic_read.rs`, `causal.rs` -- documents algorithm (edge saturation loop), data flow, error conditions, and paper references (Algorithm 1)
- Linearization solvers: `prefix.rs`, `snapshot_isolation.rs`, `serializable.rs` -- documents split-vertex semantics, `active_write`/`active_variable` constraints, witness types, and paper references (Theorems 4.8/4.10)
- `constrained_linearization.rs` -- documents the `ConstrainedLinearizationSolver` trait contract (all 7 methods), DFS search engine, and Zobrist hash memoization strategy

No logic changes -- documentation only.