### PR TITLE
docs(core): document core types and consistency check pipeline

### DIFF
--- a/crates/core/src/consistency/mod.rs
+++ b/crates/core/src/consistency/mod.rs
@@ -23,30 +23,64 @@ pub use saturation::{atomic_read, causal, committed_read, repeatable_read};
 pub use witness::Witness;
 
 /// Consistency levels supported by dbcop, ordered from weakest to strongest.
+///
+/// Each level strictly includes all weaker levels:
+/// Read Committed < Atomic Read < Causal < Prefix < Snapshot Isolation < Serializability.
+///
+/// The first three are checked in polynomial time via saturation (building a
+/// visibility relation to a fixed point). The last three additionally require
+/// finding a valid linearization and are NP-complete in the worst case.
 #[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
 #[derive(Debug, Copy, Clone)]
 pub enum Consistency {
-    /// No transaction reads from an aborted or uncommitted write.
+    /// Read Committed: no dirty reads, transactions see only committed writes.
     CommittedRead,
-    /// All reads in a transaction observe a consistent snapshot (no fractured reads).
+    /// Atomic Read: reads are atomic across variables (no fractured reads).
     AtomicRead,
-    /// Visibility is transitively closed and respects the write-write order.
+    /// Causal Consistency: causally related operations are ordered.
     Causal,
-    /// Causal plus a total order on transactions consistent with visibility.
+    /// Prefix Consistency: reads always see a consistent prefix of the write history.
     Prefix,
-    /// Prefix plus write-write conflict freedom (disjoint write sets for concurrent transactions).
+    /// Snapshot Isolation: transactions read from a consistent snapshot.
     SnapshotIsolation,
-    /// A total order on all transactions that explains every read.
+    /// Serializability: equivalent to some serial execution.
     Serializable,
 }
 
 /// Check whether the given history satisfies the specified consistency level.
 ///
-/// On success, returns a [`Witness`] proving the history is consistent.
+/// `sessions` is the recorded history: a slice of sessions, where each
+/// session is a sequence of transactions containing read/write events.
+/// `level` selects which [`Consistency`] guarantee to verify.
+///
+/// On success, returns a [`Witness`] proving the history is consistent:
+///
+/// - [`Witness::SaturationOrder`] -- for Read Committed, Atomic Read, and
+///   Causal. Contains the visibility relation (a [`DiGraph`]) computed by
+///   the saturation algorithm.
+/// - [`Witness::CommitOrder`] -- for Prefix and Serializability. Contains
+///   a linearization of transactions as `Vec<TransactionId>`.
+/// - [`Witness::SplitCommitOrder`] -- for Snapshot Isolation. Contains a
+///   linearization where each transaction is split into a read phase and a
+///   write phase: `Vec<(TransactionId, bool)>` (`true` = write phase).
+///
+/// An empty or all-empty-session history is trivially consistent and returns
+/// `Witness::CommitOrder(vec![])`.
 ///
 /// # Errors
 ///
-/// Returns an error if the history violates the consistency level.
+/// Returns [`Error::NonAtomic`](error::Error::NonAtomic) if the history has
+/// structural issues (e.g. a read observes an uncommitted write).
+///
+/// Returns [`Error::Cycle`](error::Error::Cycle) if a saturation checker
+/// (Read Committed, Atomic Read, Causal) detects a cycle in the visibility
+/// relation, with the two conflicting transaction IDs.
+///
+/// Returns [`Error::Invalid`](error::Error::Invalid) if a linearization
+/// checker (Prefix, Snapshot Isolation, Serializability) cannot find a valid
+/// ordering.
+///
+/// [`DiGraph`]: crate::graph::digraph::DiGraph
 pub fn check<Variable, Version>(
     sessions: &[Session<Variable, Version>],
     level: Consistency,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,4 +1,50 @@
-//! Maintains the core algorithms.
+//! Consistency checking for transactional histories.
+//!
+//! `dbcop_core` verifies whether a recorded database history satisfies a given
+//! transactional consistency level. It supports six levels, ordered from weakest
+//! to strongest:
+//!
+//! 1. **Read Committed** -- no transaction reads uncommitted writes.
+//! 2. **Atomic Read** -- reads within a transaction are atomic across variables
+//!    (no fractured reads).
+//! 3. **Causal Consistency** -- causally related operations appear in a
+//!    consistent order to all participants.
+//! 4. **Prefix Consistency** -- every transaction observes a consistent prefix
+//!    of the global write history.
+//! 5. **Snapshot Isolation** -- each transaction reads from a point-in-time
+//!    snapshot and concurrent writers touch disjoint key sets.
+//! 6. **Serializability** -- the history is equivalent to some serial execution
+//!    of all transactions.
+//!
+//! The first three levels (Read Committed through Causal) are checked using
+//! polynomial-time saturation algorithms that incrementally build a visibility
+//! relation until a fixed point or a cycle is found. The last three (Prefix
+//! through Serializability) first run the Causal checker, then attempt to find
+//! a valid linearization via constrained depth-first search.
+//!
+//! # Entry point
+//!
+//! The main entry point is [`check()`], which takes a slice of sessions and a
+//! [`Consistency`] level, and returns either a [`Witness`] proving the history
+//! satisfies the level, or an [`Error`](consistency::error::Error) explaining
+//! the violation.
+//!
+//! ```rust,ignore
+//! use dbcop_core::{check, Consistency};
+//!
+//! let result = check(&sessions, Consistency::Causal);
+//! match result {
+//!     Ok(witness) => println!("consistent: {witness:?}"),
+//!     Err(err) => println!("violation: {err:?}"),
+//! }
+//! ```
+//!
+//! # Crate features
+//!
+//! - **`serde`** -- enables `Serialize`/`Deserialize` derives on core types
+//!   (`DiGraph`, `TransactionId`, `Consistency`, `Witness`, `Error`).
+//!
+//! This crate is `no_std` compatible (requires `alloc`).
 
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(not(test), no_main)]


### PR DESCRIPTION
## Summary

Add Rustdoc documentation for the core types and the `check()` pipeline in `dbcop_core` (T19 + T20).

### Changes

- **`crates/core/src/lib.rs`** -- crate-level `//!` docs: what the crate does, the 6 consistency levels with descriptions, entry point usage, crate features, `no_std` note
- **`crates/core/src/graph/digraph.rs`** -- `DiGraph<T>` struct doc + key method docs (`add_edge`, `add_vertex`, `has_edge`, `is_acyclic`, `closure`, `union`, `add_edges`)
- **`crates/core/src/history/atomic/types.rs`** -- `TransactionId` struct/field docs (session_id/session_height semantics, root `(0,0)` convention), `AtomicTransactionHistory` doc, `root()` method doc
- **`crates/core/src/history/atomic/mod.rs`** -- `AtomicTransactionPO` struct doc + field docs (session_order, write_read_relation, wr_union, visibility_relation)
- **`crates/core/src/consistency/mod.rs`** -- `Consistency` enum with hierarchy note + standardized variant docs, `check()` with full parameter/return/error documentation

### Verification

- `cargo +nightly fmt --check --all` passes
- ASCII-only in all new doc comments
- No logic changes