### PR TITLE
feat(wasm): add check_consistency_trace for web visualization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,9 +152,9 @@ and `tracing::trace!` for instrumentation.
 
 ## WASM Usage
 
-The `dbcop_wasm` crate exposes a single function via `wasm_bindgen`:
+The `dbcop_wasm` crate exposes two functions via `wasm_bindgen`:
 
-`check_consistency(history_json: &str, level: &str) -> String`
+### `check_consistency(history_json: &str, level: &str) -> String`
 
 - `history_json`: JSON-encoded array of sessions (same format as CLI input
   files).
@@ -171,6 +171,43 @@ Returns a JSON string with the following schema:
   `{"ok": false, "error": "unknown consistency level"}`.
 - On malformed JSON input:
   `{"ok": false, "error": "<parse error description>"}`.
+
+### `check_consistency_trace(history_json: &str, level: &str) -> String`
+
+Same parameters as `check_consistency`. Returns a richer JSON response suitable
+for web visualization, including parsed session data and graph edges.
+
+On success:
+
+```json
+{
+  "ok": true,
+  "level": "serializable",
+  "session_count": 3,
+  "transaction_count": 12,
+  "sessions": [
+    [
+      {
+        "id": { "session_id": 1, "session_height": 0 },
+        "reads": { "0": 1 },
+        "writes": { "0": 2 },
+        "committed": true
+      }
+    ]
+  ],
+  "witness": { "CommitOrder": [...] },
+  "witness_edges": [
+    [{ "session_id": 1, "session_height": 0 }, { "session_id": 2, "session_height": 0 }]
+  ],
+  "wr_edges": [
+    [{ "session_id": 0, "session_height": 0 }, { "session_id": 1, "session_height": 0 }]
+  ]
+}
+```
+
+On check failure: same structure but with `"ok": false` and `"error"` instead of
+`"witness"`/`"witness_edges"`. The `sessions` and `wr_edges` fields are still
+present for visualization. On invalid input: `{"ok": false, "error": "..."}`.
 
 ## Key Types
 

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -9,6 +9,9 @@ extern crate alloc;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
+use dbcop_core::consistency::saturation::committed_read::check_committed_read;
+use dbcop_core::consistency::witness::Witness;
+use dbcop_core::history::atomic::types::TransactionId;
 use dbcop_core::history::raw::types::Session;
 use dbcop_core::Consistency;
 use wasm_bindgen::prelude::*;
@@ -22,6 +25,31 @@ fn parse_level(level: &str) -> Option<Consistency> {
         "snapshot-isolation" => Some(Consistency::SnapshotIsolation),
         "serializable" => Some(Consistency::Serializable),
         _ => None,
+    }
+}
+
+fn tid_to_json(tid: &TransactionId) -> serde_json::Value {
+    serde_json::json!({
+        "session_id": tid.session_id,
+        "session_height": tid.session_height
+    })
+}
+
+fn witness_edges(witness: &Witness) -> Vec<serde_json::Value> {
+    match witness {
+        Witness::SaturationOrder(graph) => graph
+            .to_edge_list()
+            .into_iter()
+            .map(|(from, to)| serde_json::json!([tid_to_json(&from), tid_to_json(&to)]))
+            .collect(),
+        Witness::CommitOrder(order) => order
+            .windows(2)
+            .map(|w| serde_json::json!([tid_to_json(&w[0]), tid_to_json(&w[1])]))
+            .collect(),
+        Witness::SplitCommitOrder(order) => order
+            .windows(2)
+            .map(|w| serde_json::json!([tid_to_json(&w[0].0), tid_to_json(&w[1].0)]))
+            .collect(),
     }
 }
 
@@ -48,5 +76,144 @@ pub fn check_consistency(history_json: &str, level: &str) -> String {
     match dbcop_core::check(&sessions, consistency) {
         Ok(witness) => serde_json::json!({"ok": true, "witness": witness}).to_string(),
         Err(error) => serde_json::json!({"ok": false, "error": error}).to_string(),
+    }
+}
+
+fn build_sessions_json(sessions: &[Session<u64, u64>]) -> (serde_json::Value, u64, u64) {
+    let session_count = sessions.len() as u64;
+    let transaction_count: u64 = sessions.iter().map(|s| s.len() as u64).sum();
+
+    let sessions_json: Vec<serde_json::Value> = sessions
+        .iter()
+        .enumerate()
+        .map(|(sid, session)| {
+            let txns: Vec<serde_json::Value> = session
+                .iter()
+                .enumerate()
+                .map(|(th, txn)| {
+                    let mut reads = serde_json::Map::new();
+                    let mut writes = serde_json::Map::new();
+                    for event in &txn.events {
+                        match event {
+                            dbcop_core::history::raw::types::Event::Read { variable, version } => {
+                                reads.insert(
+                                    variable.to_string(),
+                                    version
+                                        .as_ref()
+                                        .map_or(serde_json::Value::Null, |v| serde_json::json!(v)),
+                                );
+                            }
+                            dbcop_core::history::raw::types::Event::Write { variable, version } => {
+                                writes.insert(variable.to_string(), serde_json::json!(version));
+                            }
+                        }
+                    }
+                    serde_json::json!({
+                        "id": {
+                            "session_id": (sid as u64) + 1,
+                            "session_height": th as u64
+                        },
+                        "reads": reads,
+                        "writes": writes,
+                        "committed": txn.committed
+                    })
+                })
+                .collect();
+            serde_json::json!(txns)
+        })
+        .collect();
+
+    (
+        serde_json::json!(sessions_json),
+        session_count,
+        transaction_count,
+    )
+}
+
+/// Check consistency and return a rich trace suitable for web visualization.
+///
+/// Returns a JSON string with session metadata, witness details, and graph edges
+/// that a web UI can use to render the history and its consistency proof/violation.
+///
+/// On success:
+/// ```json
+/// {
+///   "ok": true,
+///   "level": "serializable",
+///   "session_count": 3,
+///   "transaction_count": 12,
+///   "sessions": [[{"id":...,"reads":...,"writes":...,"committed":true},...],...],
+///   "witness": { ... },
+///   "witness_edges": [[from_id, to_id], ...],
+///   "wr_edges": [[from_id, to_id], ...]
+/// }
+/// ```
+///
+/// On failure:
+/// ```json
+/// {
+///   "ok": false,
+///   "level": "causal",
+///   "session_count": 2,
+///   "transaction_count": 5,
+///   "sessions": [...],
+///   "error": { ... }
+/// }
+/// ```
+///
+/// On invalid input: `{"ok": false, "error": "..."}`
+#[must_use]
+#[wasm_bindgen]
+pub fn check_consistency_trace(history_json: &str, level: &str) -> String {
+    let Some(consistency) = parse_level(level) else {
+        return serde_json::json!({"ok": false, "error": "unknown consistency level"}).to_string();
+    };
+
+    let sessions = match serde_json::from_str::<Vec<Session<u64, u64>>>(history_json) {
+        Ok(s) => s,
+        Err(e) => {
+            return serde_json::json!({"ok": false, "error": e.to_string()}).to_string();
+        }
+    };
+
+    let (sessions_json, session_count, transaction_count) = build_sessions_json(&sessions);
+
+    let wr_edges: Vec<serde_json::Value> = check_committed_read(&sessions)
+        .ok()
+        .map(|graph| {
+            graph
+                .to_edge_list()
+                .into_iter()
+                .map(|(from, to)| serde_json::json!([tid_to_json(&from), tid_to_json(&to)]))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let level_str = level;
+
+    match dbcop_core::check(&sessions, consistency) {
+        Ok(witness) => {
+            let edges = witness_edges(&witness);
+            serde_json::json!({
+                "ok": true,
+                "level": level_str,
+                "session_count": session_count,
+                "transaction_count": transaction_count,
+                "sessions": sessions_json,
+                "witness": witness,
+                "witness_edges": edges,
+                "wr_edges": wr_edges
+            })
+            .to_string()
+        }
+        Err(error) => serde_json::json!({
+            "ok": false,
+            "level": level_str,
+            "session_count": session_count,
+            "transaction_count": transaction_count,
+            "sessions": sessions_json,
+            "error": error
+        })
+        .to_string(),
     }
 }


### PR DESCRIPTION
## Summary

- Add `check_consistency_trace()` wasm_bindgen function that returns rich JSON output for web visualization
- Includes parsed session data (transactions with reads/writes/committed status), witness edges, and write-read edges
- On success: returns `ok`, `level`, `session_count`, `transaction_count`, `sessions`, `witness`, `witness_edges`, `wr_edges`
- On failure: returns same metadata plus `error` instead of witness fields
- Existing `check_consistency()` function unchanged

## Changes

- `crates/wasm/src/lib.rs`: new `check_consistency_trace` function + helpers (`tid_to_json`, `witness_edges`, `build_sessions_json`)
- `AGENTS.md`: updated WASM Usage section documenting both functions with JSON schema examples