### PR TITLE
feat(web): Deno web app scaffold with WASM integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,12 +105,13 @@ dbcop/                          workspace root
     sat/                         SAT solver backend -- dbcop_sat
     testgen/                     test history generator -- dbcop_testgen
     drivers/                     database drivers -- dbcop_drivers
+  web/                           Deno web app: history input, WASM integration, graph visualization
   .github/workflows/
     rust.yml                     build + format CI
     code-quality.yml             taplo + deno fmt + typos CI
   .husky/pre-commit              ASCII check + cargo +nightly fmt
   taplo.toml                     TOML formatter config
-  deno.json                      deno tasks: prepare (husky), wasmbuild
+  deno.json                      deno tasks: prepare (husky), wasmbuild, serve-web
   rustfmt.toml                   nightly rustfmt config
 ```
 

--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,8 @@
   "nodeModulesDir": "auto",
   "tasks": {
     "wasmbuild": "deno run -A jsr:@deno/wasmbuild@0.21.0 --project dbcop_wasm --out wasmlib",
-    "prepare": "deno run -A npm:husky"
+    "prepare": "deno run -A npm:husky",
+    "serve-web": "deno run --allow-net --allow-read jsr:@std/http@1/file-server web/"
   },
   "fmt": {
     "exclude": [".sisyphus"]

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,5 @@
+[default.extend-identifiers]
+# dbcop is the project name, not a typo of "debug" or similar
+dbcop = "dbcop"
+# ba is a SAT literal variable name (b-before-a), not a typo of "by" or "be"
+ba = "ba"

--- a/web/index.html
+++ b/web/index.html
@@ -1,36 +1,43 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>dbcop -- Transactional Consistency Checker</title>
-  <link rel="stylesheet" href="style.css" />
-</head>
-<body>
-  <header><h1>dbcop</h1><p>Transactional Consistency Checker</p></header>
-  <main>
-    <section id="input-section">
-      <h2>History Input</h2>
-      <textarea id="history-json" rows="10" placeholder="Enter history JSON..."></textarea>
-      <select id="level-select">
-        <option value="committed-read">Read Committed</option>
-        <option value="atomic-read">Atomic Read</option>
-        <option value="causal">Causal Consistency</option>
-        <option value="prefix">Prefix Consistency</option>
-        <option value="snapshot-isolation">Snapshot Isolation</option>
-        <option value="serializable" selected>Serializability</option>
-      </select>
-      <button id="check-btn">Check Consistency</button>
-    </section>
-    <section id="result-section">
-      <h2>Result</h2>
-      <pre id="result-output">Run a check to see results.</pre>
-    </section>
-    <section id="graph-section">
-      <h2>Transaction Graph</h2>
-      <div id="graph-container"></div>
-    </section>
-  </main>
-  <script type="module" src="main.ts"></script>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>dbcop -- Transactional Consistency Checker</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header>
+      <h1>dbcop</h1>
+      <p>Transactional Consistency Checker</p>
+    </header>
+    <main>
+      <section id="input-section">
+        <h2>History Input</h2>
+        <textarea
+          id="history-json"
+          rows="10"
+          placeholder="Enter history JSON..."
+        ></textarea>
+        <select id="level-select">
+          <option value="committed-read">Read Committed</option>
+          <option value="atomic-read">Atomic Read</option>
+          <option value="causal">Causal Consistency</option>
+          <option value="prefix">Prefix Consistency</option>
+          <option value="snapshot-isolation">Snapshot Isolation</option>
+          <option value="serializable" selected>Serializability</option>
+        </select>
+        <button id="check-btn">Check Consistency</button>
+      </section>
+      <section id="result-section">
+        <h2>Result</h2>
+        <pre id="result-output">Run a check to see results.</pre>
+      </section>
+      <section id="graph-section">
+        <h2>Transaction Graph</h2>
+        <div id="graph-container"></div>
+      </section>
+    </main>
+    <script type="module" src="main.ts"></script>
+  </body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>dbcop -- Transactional Consistency Checker</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header><h1>dbcop</h1><p>Transactional Consistency Checker</p></header>
+  <main>
+    <section id="input-section">
+      <h2>History Input</h2>
+      <textarea id="history-json" rows="10" placeholder="Enter history JSON..."></textarea>
+      <select id="level-select">
+        <option value="committed-read">Read Committed</option>
+        <option value="atomic-read">Atomic Read</option>
+        <option value="causal">Causal Consistency</option>
+        <option value="prefix">Prefix Consistency</option>
+        <option value="snapshot-isolation">Snapshot Isolation</option>
+        <option value="serializable" selected>Serializability</option>
+      </select>
+      <button id="check-btn">Check Consistency</button>
+    </section>
+    <section id="result-section">
+      <h2>Result</h2>
+      <pre id="result-output">Run a check to see results.</pre>
+    </section>
+    <section id="graph-section">
+      <h2>Transaction Graph</h2>
+      <div id="graph-container"></div>
+    </section>
+  </main>
+  <script type="module" src="main.ts"></script>
+</body>
+</html>

--- a/web/main.ts
+++ b/web/main.ts
@@ -1,0 +1,53 @@
+import { check_consistency_trace } from "../wasmlib/dbcop_wasm.js";
+
+// Example: 2 sessions, 3 transactions total.
+// Session 0: T0 writes x0=1, T1 reads x0=1.
+// Session 1: T0 writes x0=2.
+// Format: Vec<Vec<Transaction>> where Transaction = {events, committed}.
+const EXAMPLE_HISTORY = JSON.stringify([
+  [
+    {
+      events: [{ Write: { variable: 0, version: 1 } }],
+      committed: true,
+    },
+    {
+      events: [{ Read: { variable: 0, version: 1 } }],
+      committed: true,
+    },
+  ],
+  [
+    {
+      events: [{ Write: { variable: 0, version: 2 } }],
+      committed: true,
+    },
+  ],
+]);
+
+function setup(): void {
+  const historyInput = document.getElementById(
+    "history-json",
+  ) as HTMLTextAreaElement;
+  const levelSelect = document.getElementById(
+    "level-select",
+  ) as HTMLSelectElement;
+  const checkBtn = document.getElementById("check-btn") as HTMLButtonElement;
+  const resultOutput = document.getElementById(
+    "result-output",
+  ) as HTMLPreElement;
+
+  historyInput.value = EXAMPLE_HISTORY;
+
+  checkBtn.addEventListener("click", () => {
+    const history = historyInput.value;
+    const level = levelSelect.value;
+    try {
+      const result = check_consistency_trace(history, level);
+      const parsed = JSON.parse(result);
+      resultOutput.textContent = JSON.stringify(parsed, null, 2);
+    } catch (e) {
+      resultOutput.textContent = "Error: " + String(e);
+    }
+  });
+}
+
+setup();

--- a/web/style.css
+++ b/web/style.css
@@ -1,0 +1,25 @@
+:root {
+  --bg: #0f0f1a;
+  --surface: #1a1a2e;
+  --accent: #4361ee;
+  --text: #e0e0e0;
+  --muted: #888;
+  --border: #333;
+  --success: #4cc9a0;
+  --error: #f72585;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body { background: var(--bg); color: var(--text); font-family: system-ui, sans-serif; padding: 2rem; }
+header { margin-bottom: 2rem; }
+header h1 { font-size: 2rem; color: var(--accent); font-family: monospace; }
+header p { color: var(--muted); }
+main { display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; }
+section { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 1.5rem; }
+section h2 { font-size: 1rem; text-transform: uppercase; color: var(--muted); letter-spacing: 0.1em; margin-bottom: 1rem; }
+#graph-section { grid-column: 1 / -1; }
+textarea { width: 100%; font-family: monospace; font-size: 0.85rem; background: var(--bg); color: var(--text); border: 1px solid var(--border); border-radius: 4px; padding: 0.75rem; resize: vertical; }
+select { width: 100%; padding: 0.5rem; margin-top: 0.5rem; background: var(--bg); color: var(--text); border: 1px solid var(--border); border-radius: 4px; }
+button { margin-top: 1rem; padding: 0.75rem 2rem; background: var(--accent); color: #fff; border: none; border-radius: 4px; cursor: pointer; font-size: 1rem; width: 100%; }
+button:hover { opacity: 0.9; }
+pre { font-family: monospace; font-size: 0.8rem; overflow: auto; white-space: pre-wrap; word-break: break-word; color: var(--text); }
+#graph-container { min-height: 300px; background: var(--bg); border-radius: 4px; display: flex; align-items: center; justify-content: center; color: var(--muted); }

--- a/web/style.css
+++ b/web/style.css
@@ -8,18 +8,97 @@
   --success: #4cc9a0;
   --error: #f72585;
 }
-* { box-sizing: border-box; margin: 0; padding: 0; }
-body { background: var(--bg); color: var(--text); font-family: system-ui, sans-serif; padding: 2rem; }
-header { margin-bottom: 2rem; }
-header h1 { font-size: 2rem; color: var(--accent); font-family: monospace; }
-header p { color: var(--muted); }
-main { display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; }
-section { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 1.5rem; }
-section h2 { font-size: 1rem; text-transform: uppercase; color: var(--muted); letter-spacing: 0.1em; margin-bottom: 1rem; }
-#graph-section { grid-column: 1 / -1; }
-textarea { width: 100%; font-family: monospace; font-size: 0.85rem; background: var(--bg); color: var(--text); border: 1px solid var(--border); border-radius: 4px; padding: 0.75rem; resize: vertical; }
-select { width: 100%; padding: 0.5rem; margin-top: 0.5rem; background: var(--bg); color: var(--text); border: 1px solid var(--border); border-radius: 4px; }
-button { margin-top: 1rem; padding: 0.75rem 2rem; background: var(--accent); color: #fff; border: none; border-radius: 4px; cursor: pointer; font-size: 1rem; width: 100%; }
-button:hover { opacity: 0.9; }
-pre { font-family: monospace; font-size: 0.8rem; overflow: auto; white-space: pre-wrap; word-break: break-word; color: var(--text); }
-#graph-container { min-height: 300px; background: var(--bg); border-radius: 4px; display: flex; align-items: center; justify-content: center; color: var(--muted); }
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: system-ui, sans-serif;
+  padding: 2rem;
+}
+header {
+  margin-bottom: 2rem;
+}
+header h1 {
+  font-size: 2rem;
+  color: var(--accent);
+  font-family: monospace;
+}
+header p {
+  color: var(--muted);
+}
+main {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+}
+section {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 1.5rem;
+}
+section h2 {
+  font-size: 1rem;
+  text-transform: uppercase;
+  color: var(--muted);
+  letter-spacing: 0.1em;
+  margin-bottom: 1rem;
+}
+#graph-section {
+  grid-column: 1 / -1;
+}
+textarea {
+  width: 100%;
+  font-family: monospace;
+  font-size: 0.85rem;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0.75rem;
+  resize: vertical;
+}
+select {
+  width: 100%;
+  padding: 0.5rem;
+  margin-top: 0.5rem;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+button {
+  margin-top: 1rem;
+  padding: 0.75rem 2rem;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+  width: 100%;
+}
+button:hover {
+  opacity: 0.9;
+}
+pre {
+  font-family: monospace;
+  font-size: 0.8rem;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--text);
+}
+#graph-container {
+  min-height: 300px;
+  background: var(--bg);
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
+}


### PR DESCRIPTION
## Summary

- Add `web/index.html` with history JSON input, consistency level selector, result display, and graph container
- Add `web/main.ts` importing `check_consistency_trace` from compiled WASM (`wasmlib/dbcop_wasm.js`) with example history
- Add `web/style.css` with dark theme, clean monospace typography
- Add `serve-web` task to root `deno.json` using `jsr:@std/http@1/file-server`
- Update `AGENTS.md` repository structure with `web/` entry

## Usage

```bash
deno task wasmbuild    # build WASM to wasmlib/
deno task serve-web    # serve web/ on localhost
```

## Notes

- Vanilla TypeScript + HTML only (no frameworks)
- ASCII-only in all source files
- Example history uses correct `{events, committed}` Transaction format
- Graph visualization placeholder ready for future implementation