### PR TITLE
chore(deps): upgrade rand 0.9 to 0.10, fix RngExt breaking change

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ hashbrown          = { version = "0.16" }
 wasm-bindgen       = { version = "=0.2.106" }
 typed-builder      = { version = "0.23" }
 chrono             = { version = "0.4" }
-rand               = { version = "0.9" }
+rand               = { version = "0.10" }
 rayon              = { version = "1.10" }
 derive_more        = { version = "2.1", default-features = false, features = [ "from" ] }
 

--- a/crates/testgen/src/generator.rs
+++ b/crates/testgen/src/generator.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use chrono::{DateTime, Duration, Local};
 use dbcop_core::history::raw::types::{Event, Session, Transaction};
 use rand::distr::{Distribution, Uniform};
-use rand::Rng;
+use rand::RngExt;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use serde::{Deserialize, Serialize};
 use typed_builder::TypedBuilder;


### PR DESCRIPTION
## Summary
- Bump rand from 0.9 to 0.10 in workspace Cargo.toml
- Fix breaking change: `Rng::random()` moved to `RngExt` trait in rand 0.10; update import in crates/testgen/src/generator.rs from `use rand::Rng` to `use rand::RngExt`
- All other rand 0.10 APIs used (rand::rng(), rand::distr::Uniform, rand::distr::Distribution) are unchanged