### PR TITLE
feat(ci): GitHub Pages deployment, zizmor security linting, action version updates

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -2,15 +2,20 @@ name: Code Quality Checks
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   code-quality:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Spell Check with Typos
-        uses: crate-ci/typos@master
+        uses: crate-ci/typos@v1.43.5
 
       - name: Install Taplo
         uses: taiki-e/cache-cargo-install-action@v3

--- a/.github/workflows/deno.yaml
+++ b/.github/workflows/deno.yaml
@@ -6,11 +6,16 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   deno:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,0 +1,58 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+
+      - name: Set up Deno
+        uses: denoland/setup-deno@v2
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build
+        run: deno task build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: ./dist
+
+  deploy:
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -15,6 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -38,4 +43,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions-rust-lang/rustfmt@v1

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,7 @@
+# zizmor security linting configuration
+# We use version-tag pinned refs (e.g. @v4, @v1.43.5) instead of SHA hash pins.
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "*": ref-pin

--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,8 @@ wasmlib/
 .omc/
 .claude/
 
+# Static site build output
+dist/
+
 # Node modules (Deno nodeModulesDir)
 node_modules/

--- a/deno.json
+++ b/deno.json
@@ -7,15 +7,25 @@
     "deno:fmt": "deno fmt --check",
     "deno:lint": "deno lint",
     "deno:check": "deno check web/main.ts",
-    "deno:ci": "deno task deno:fmt && deno task deno:lint && deno task deno:check"
+    "deno:ci": "deno task deno:fmt && deno task deno:lint && deno task deno:check",
+    "build": "deno task wasmbuild && deno run -A web/build.ts"
   },
   "imports": {
-    "@std/assert": "jsr:@std/assert@^1.0.19"
+    "@std/assert": "jsr:@std/assert@^1.0.19",
+    "@std/fs": "jsr:@std/fs@1",
+    "esbuild": "npm:esbuild@0.25.0"
   },
   "compilerOptions": {
     "lib": ["dom", "dom.iterable", "esnext", "deno.ns"]
   },
   "fmt": {
-    "exclude": [".sisyphus", ".omc", ".claude", "node_modules", "wasmlib"]
+    "exclude": [
+      ".sisyphus",
+      ".omc",
+      ".claude",
+      "node_modules",
+      "wasmlib",
+      "dist"
+    ]
   }
 }

--- a/web/build.ts
+++ b/web/build.ts
@@ -1,0 +1,30 @@
+import { copy, ensureDir } from "@std/fs";
+
+const dist = "dist";
+await ensureDir(dist);
+
+await copy("web/index.html", `${dist}/index.html`, { overwrite: true });
+await copy("web/style.css", `${dist}/style.css`, { overwrite: true });
+await copy("wasmlib", `${dist}/wasmlib`, { overwrite: true });
+
+let html = await Deno.readTextFile(`${dist}/index.html`);
+html = html.replace('src="main.ts"', 'src="main.js"');
+await Deno.writeTextFile(`${dist}/index.html`, html);
+
+const esbuild = await import("esbuild");
+await esbuild.default.build({
+  entryPoints: ["web/main.ts"],
+  bundle: true,
+  format: "esm",
+  platform: "browser",
+  external: ["../wasmlib/dbcop_wasm.js"],
+  outfile: `${dist}/main.js`,
+  minify: true,
+});
+await esbuild.default.stop();
+
+let js = await Deno.readTextFile(`${dist}/main.js`);
+js = js.replaceAll("../wasmlib/dbcop_wasm.js", "./wasmlib/dbcop_wasm.js");
+await Deno.writeTextFile(`${dist}/main.js`, js);
+
+console.log("Build complete: dist/");


### PR DESCRIPTION
## Summary
- Add `.github/zizmor.yml`: suppress hash-pin lint, allow tag-pinned action refs
- Fix all zizmor security lints (artipacked, excessive-permissions) in all workflow files
- Pin `crate-ci/typos` to `@v1.43.5` (was `@master`)
- Add `.github/workflows/pages.yaml`: build static site and deploy to GitHub Pages on push to main
- Add `web/build.ts`: esbuild-based TypeScript bundler for static deployment
- Add `deno task build`: wasmbuild + bundle to `dist/`
- Add `dist/` to `.gitignore` and deno fmt exclude
- Comprehensive AGENTS.md update: act validation, zizmor, GitHub Pages, build pipeline, pre-commit hook docs