### PR TITLE
perf(core): wire connected-component decomposition into DFS and SAT check pipelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,10 +319,12 @@ notepads, and agent memory.
   sets in `causal_ww()` and `causal_rw()` hot paths to avoid repeated DiGraph
   clones per iteration.
 
-- Communication graph decomposition (`consistency/decomposition.rs`): builds a
-  `UGraph<u64>` of session interactions based on shared variable access. Used
-  for biconnected component decomposition (Theorem 5.2) to reduce NP-complete
-  checker complexity by solving independent sub-histories separately.
+- Communication graph decomposition (`consistency/mod.rs`, `dbcop_sat/lib.rs`):
+  decomposes history by connected components of the communication graph (Theorem
+  5.2 from Biswas & Enea 2019). Checks each component independently, then remaps
+  and merges witnesses. Reduces DFS/SAT search space from O(n!) to O(sum of
+  k_i!) where k_i are component sizes. Applied to NP-complete levels only:
+  Prefix, SnapshotIsolation, Serializable.
 
 - Incremental transitive closure (`digraph.rs`): `incremental_closure()` extends
   an existing closed graph with new edges using BFS ancestor/descendant
@@ -335,6 +337,9 @@ notepads, and agent memory.
 - Integration tests: `tests/` directories under each crate.
 - `crates/core/tests/paper_polynomial.rs` -- 13 tests verifying polynomial-time
   checker correctness against known histories.
+- `crates/core/tests/decomposition_check.rs` -- 3 tests verifying communication
+  graph decomposition in NP-complete checkers (independent clusters, single
+  cluster fallback, write-skew detection across components).
 - `crates/core/benches/consistency.rs` -- 18 Criterion benchmarks (6 consistency
   levels x 3 history sizes).
 - Always add tests when adding new functionality.

--- a/crates/core/src/history/raw/types.rs
+++ b/crates/core/src/history/raw/types.rs
@@ -98,6 +98,7 @@ where
 
 /// A sequence of events executed atomically, either committed or aborted.
 #[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+#[derive(Clone)]
 pub struct Transaction<Variable, Version> {
     pub events: Vec<Event<Variable, Version>>,
     pub committed: bool,

--- a/crates/core/tests/decomposition_check.rs
+++ b/crates/core/tests/decomposition_check.rs
@@ -1,0 +1,91 @@
+//! Tests for communication graph decomposition in consistency checkers.
+
+use dbcop_core::consistency::Witness;
+use dbcop_core::history::raw::types::{Event, Transaction};
+use dbcop_core::{check, Consistency};
+
+type History = Vec<Vec<Transaction<&'static str, u64>>>;
+
+fn session(txns: Vec<Transaction<&'static str, u64>>) -> Vec<Transaction<&'static str, u64>> {
+    txns
+}
+
+#[test]
+fn decomposition_two_independent_clusters_serializable_pass() {
+    // Sessions {1,2} share var "x"; sessions {3,4} share var "y".
+    // The two clusters are completely independent -> decomposed into 2 components.
+    let history: History = vec![
+        session(vec![Transaction::committed(vec![Event::write("x", 1)])]),
+        session(vec![Transaction::committed(vec![Event::read("x", 1)])]),
+        session(vec![Transaction::committed(vec![Event::write("y", 1)])]),
+        session(vec![Transaction::committed(vec![Event::read("y", 1)])]),
+    ];
+    let result = check(&history, Consistency::Serializable);
+    assert!(result.is_ok(), "expected pass, got: {result:?}");
+    // Witness must cover all 4 sessions (all original session IDs present).
+    let Witness::CommitOrder(order) = result.unwrap() else {
+        panic!("expected CommitOrder witness");
+    };
+    // Each session has 1 transaction so we expect 4 entries total.
+    assert_eq!(
+        order.len(),
+        4,
+        "expected 4 transactions in merged CommitOrder"
+    );
+    // All 4 original session IDs should appear.
+    let ids: std::collections::HashSet<u64> = order.iter().map(|tid| tid.session_id).collect();
+    assert!(ids.contains(&1));
+    assert!(ids.contains(&2));
+    assert!(ids.contains(&3));
+    assert!(ids.contains(&4));
+}
+
+#[test]
+fn decomposition_single_cluster_fallback_serializable_pass() {
+    // All sessions share var "x" -> single connected component -> fallback to direct DFS.
+    let history: History = vec![
+        session(vec![Transaction::committed(vec![Event::write("x", 1)])]),
+        session(vec![Transaction::committed(vec![Event::read("x", 1)])]),
+        session(vec![Transaction::committed(vec![Event::read("x", 1)])]),
+    ];
+    let result = check(&history, Consistency::Serializable);
+    assert!(result.is_ok(), "expected pass, got: {result:?}");
+}
+
+#[test]
+fn decomposition_one_failing_cluster_serializable_fail() {
+    // Sessions {1,2} share var "x" (valid).
+    // Sessions {3,4,5} share vars "a"/"b" with write-skew (not serializable).
+    // After decomposition, cluster {3,4,5} fails -> overall fails.
+    //
+    // Write-skew pattern:
+    //   s3: write(a, 1), write(b, 1)
+    //   s4: read(a, 1), write(b, 2)    <- reads a from s3, overwrites b
+    //   s5: read(b, 1), write(a, 2)    <- reads b from s3, overwrites a
+    // Both s4 and s5 see the values written by s3 but write conflicting values.
+    // No serial order exists: s4<s5 requires s5 to see b=2 (contradicts read b=1);
+    // s5<s4 requires s4 to see a=2 (contradicts read a=1).
+    let history: History = vec![
+        // Cluster 1: sessions 1,2 (share "x")
+        session(vec![Transaction::committed(vec![Event::write("x", 1)])]),
+        session(vec![Transaction::committed(vec![Event::read("x", 1)])]),
+        // Cluster 2: sessions 3,4,5 (share "a","b") -- write skew
+        session(vec![Transaction::committed(vec![
+            Event::write("a", 1),
+            Event::write("b", 1),
+        ])]),
+        session(vec![Transaction::committed(vec![
+            Event::read("a", 1),
+            Event::write("b", 2),
+        ])]),
+        session(vec![Transaction::committed(vec![
+            Event::read("b", 1),
+            Event::write("a", 2),
+        ])]),
+    ];
+    let result = check(&history, Consistency::Serializable);
+    assert!(
+        result.is_err(),
+        "expected serializable violation, got: {result:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Wire Theorem 5.2 decomposition into Prefix/SnapshotIsolation/Serializable check paths. Reduces search space for NP-complete levels by checking independent session groups separately. Update AGENTS.md with performance decision.

## Changes

- **decomposition.rs**: Add `connected_components()` fn, remove `#[allow(dead_code)]`
- **consistency/mod.rs**: Add helper fns + update 3 match arms + change module visibility
- **sat/lib.rs**: Add decomposition to 3 public functions
- **decomposition_check.rs**: New test file with 3 tests
- **AGENTS.md**: Add 1 performance decision entry
- **raw/types.rs**: Add Clone derive to Transaction

## Verification

- ✅ `cargo test --workspace` passes
- ✅ `cargo clippy -p dbcop_core -p dbcop_sat -- -D warnings` passes
- ✅ All 3 new decomposition tests pass