### PR TITLE
chore: add *.png to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ dist/
 
 # Node modules (Deno nodeModulesDir)
 node_modules/
+
+# Screenshots
+*.png


### PR DESCRIPTION
## Summary
- Add `*.png` to `.gitignore` to prevent accidentally committing screenshots
- Used for local Playwright debugging of the dbcop web UI

## Notes
- WASM ESM loading requires route interception in Playwright (Deno wasmbuild uses `import * as wasm from "./dbcop_wasm.wasm"` which browsers don't support natively)
- Screenshot verified: page loads, example history populates textarea, consistency check returns PASS with CommitOrder witness, transaction graph renders