### PR TITLE
feat: compact text DSL, web UI redesign, and compact serde

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -1,6 +1,12 @@
 name: Code Quality Checks
 on:
+  push:
+    branches: ["main"]
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/deno.yaml
+++ b/.github/workflows/deno.yaml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: ["main"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: ["main"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
   "crates/core",
+  "crates/parser",
   "crates/testgen",
   "crates/cli",
   "crates/wasm",
@@ -27,6 +28,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 dbcop_core    = { version = "0.2.0", path = "crates/core" }
+dbcop_parser  = { version = "0.2.0", path = "crates/parser" }
 dbcop_testgen = { version = "0.2.0", path = "crates/testgen" }
 
 clap               = { version = "4.5", features = [ "derive" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ chrono             = { version = "0.4" }
 rand               = { version = "0.10" }
 rayon              = { version = "1.10" }
 derive_more        = { version = "2.1", default-features = false, features = [ "from" ] }
+winnow             = { version = "0.7" }
+logos              = { version = "0.15" }
 
 [workspace.lints.rust]
 unused_qualifications = "warn"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -15,7 +15,7 @@ name = "dbcop"
 path = "src/main.rs"
 
 [dependencies]
-dbcop_core    = { workspace = true, features = [ "serde" ] }
+dbcop_core    = { workspace = true, features = [ "serde", "parser" ] }
 dbcop_testgen = { workspace = true }
 
 clap               = { workspace = true }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -15,7 +15,8 @@ name = "dbcop"
 path = "src/main.rs"
 
 [dependencies]
-dbcop_core    = { workspace = true, features = [ "serde", "parser" ] }
+dbcop_core    = { workspace = true, features = [ "serde" ] }
+dbcop_parser  = { workspace = true }
 dbcop_testgen = { workspace = true }
 
 clap               = { workspace = true }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -20,6 +20,8 @@ pub enum Command {
     Generate(GenerateArgs),
     /// Verify consistency of transactional histories
     Verify(VerifyArgs),
+    /// Format compact history (.hist) files
+    Fmt(FmtArgs),
 }
 
 #[derive(Debug, Parser)]
@@ -68,6 +70,16 @@ pub enum ConsistencyLevel {
     Prefix,
     SnapshotIsolation,
     Serializable,
+}
+
+#[derive(Debug, Parser)]
+pub struct FmtArgs {
+    /// Input files or directories to format (glob patterns supported)
+    #[arg(required = true)]
+    pub paths: Vec<PathBuf>,
+    /// Check formatting without modifying files (exit 1 if unformatted)
+    #[arg(long)]
+    pub check: bool,
 }
 
 impl From<ConsistencyLevel> for dbcop_core::Consistency {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -103,11 +103,10 @@ fn verify(args: &dbcop_cli::VerifyArgs) {
                 eprintln!("Failed to read {filename}: {e}");
                 process::exit(1);
             });
-            let sessions = dbcop_core::history::raw::parser::parse_history(&content)
-                .unwrap_or_else(|e| {
-                    eprintln!("Failed to parse {filename}: {e}");
-                    process::exit(1);
-                });
+            let sessions = dbcop_parser::parse_history(&content).unwrap_or_else(|e| {
+                eprintln!("Failed to parse {filename}: {e}");
+                process::exit(1);
+            });
             dbcop_core::check(&sessions, level).map_err(|e| format!("{e:?}"))
         };
 
@@ -174,11 +173,10 @@ fn fmt(args: &dbcop_cli::FmtArgs) {
             process::exit(1);
         });
 
-        let sessions =
-            dbcop_core::history::raw::parser::parse_history(&content).unwrap_or_else(|e| {
-                eprintln!("Failed to parse {}: {e}", path.display());
-                process::exit(1);
-            });
+        let sessions = dbcop_parser::parse_history(&content).unwrap_or_else(|e| {
+            eprintln!("Failed to parse {}: {e}", path.display());
+            process::exit(1);
+        });
 
         let formatted = dbcop_core::history::raw::display::format_history(&sessions);
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -13,6 +13,7 @@ fn main() {
     match &app.command {
         Command::Generate(args) => generate(args),
         Command::Verify(args) => verify(args),
+        Command::Fmt(args) => fmt(args),
     }
 }
 
@@ -59,32 +60,58 @@ fn verify(args: &dbcop_cli::VerifyArgs) {
             process::exit(1);
         })
         .filter_map(Result::ok)
-        .filter(|e| e.path().extension().is_some_and(|ext| ext == "json"))
+        .filter(|e| {
+            e.path()
+                .extension()
+                .is_some_and(|ext| ext == "json" || ext == "hist" || ext == "txt")
+        })
         .collect();
 
     entries.sort_by_key(fs::DirEntry::path);
 
     if entries.is_empty() {
-        eprintln!("No .json files found in {}", args.input_dir.display());
+        eprintln!(
+            "No .json, .hist, or .txt files found in {}",
+            args.input_dir.display()
+        );
         process::exit(1);
     }
 
     for entry in entries {
         let path = entry.path();
         let filename = path.file_name().unwrap_or_default().to_string_lossy();
+        let ext = path
+            .extension()
+            .map(|e| e.to_string_lossy().into_owned())
+            .unwrap_or_default();
 
-        let file = fs::File::open(&path).unwrap_or_else(|e| {
-            eprintln!("Failed to open {filename}: {e}");
-            process::exit(1);
-        });
-
-        let history: dbcop_testgen::generator::History = serde_json::from_reader(file)
-            .unwrap_or_else(|e| {
-                eprintln!("Failed to parse {filename}: {e}");
+        // outcome: Ok(()) = pass, Err(msg) = fail with debug string
+        let outcome: Result<dbcop_core::consistency::witness::Witness, String> = if ext == "json" {
+            let file = fs::File::open(&path).unwrap_or_else(|e| {
+                eprintln!("Failed to open {filename}: {e}");
                 process::exit(1);
             });
+            let history: dbcop_testgen::generator::History = serde_json::from_reader(file)
+                .unwrap_or_else(|e| {
+                    eprintln!("Failed to parse {filename}: {e}");
+                    process::exit(1);
+                });
+            dbcop_core::check(history.get_data(), level).map_err(|e| format!("{e:?}"))
+        } else {
+            // .hist or .txt
+            let content = fs::read_to_string(&path).unwrap_or_else(|e| {
+                eprintln!("Failed to read {filename}: {e}");
+                process::exit(1);
+            });
+            let sessions = dbcop_core::history::raw::parser::parse_history(&content)
+                .unwrap_or_else(|e| {
+                    eprintln!("Failed to parse {filename}: {e}");
+                    process::exit(1);
+                });
+            dbcop_core::check(&sessions, level).map_err(|e| format!("{e:?}"))
+        };
 
-        match dbcop_core::check(history.get_data(), level) {
+        match outcome {
             Ok(witness) => {
                 if args.json {
                     let result = serde_json::json!({
@@ -111,9 +138,9 @@ fn verify(args: &dbcop_cli::VerifyArgs) {
                     println!("{}", serde_json::to_string(&result).unwrap());
                 } else if args.verbose {
                     println!("{filename}: FAIL");
-                    println!("  error: {e:?}");
+                    println!("  error: {e}");
                 } else {
-                    println!("{filename}: FAIL ({e:?})");
+                    println!("{filename}: FAIL ({e})");
                 }
             }
         }
@@ -121,5 +148,79 @@ fn verify(args: &dbcop_cli::VerifyArgs) {
 
     if any_failed {
         process::exit(1);
+    }
+}
+
+fn fmt(args: &dbcop_cli::FmtArgs) {
+    let mut hist_files: Vec<std::path::PathBuf> = Vec::new();
+
+    for path in &args.paths {
+        if path.is_file() {
+            hist_files.push(path.clone());
+        } else if path.is_dir() {
+            // Recursively find all .hist files in the directory.
+            collect_hist_files(path, &mut hist_files);
+        } else {
+            eprintln!("Path not found: {}", path.display());
+            process::exit(1);
+        }
+    }
+
+    let mut reformatted = 0usize;
+
+    for path in &hist_files {
+        let content = fs::read_to_string(path).unwrap_or_else(|e| {
+            eprintln!("Failed to read {}: {e}", path.display());
+            process::exit(1);
+        });
+
+        let sessions =
+            dbcop_core::history::raw::parser::parse_history(&content).unwrap_or_else(|e| {
+                eprintln!("Failed to parse {}: {e}", path.display());
+                process::exit(1);
+            });
+
+        let formatted = dbcop_core::history::raw::display::format_history(&sessions);
+
+        if formatted != content {
+            reformatted += 1;
+            if args.check {
+                println!("Would reformat: {}", path.display());
+            } else {
+                fs::write(path, &formatted).unwrap_or_else(|e| {
+                    eprintln!("Failed to write {}: {e}", path.display());
+                    process::exit(1);
+                });
+                println!("Reformatted: {}", path.display());
+            }
+        }
+    }
+
+    if args.check {
+        if reformatted > 0 {
+            println!("{reformatted} file(s) would be reformatted");
+            process::exit(1);
+        } else {
+            println!("All files are correctly formatted");
+        }
+    } else {
+        println!("{reformatted} file(s) reformatted");
+    }
+}
+
+fn collect_hist_files(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+    let entries = fs::read_dir(dir).unwrap_or_else(|e| {
+        eprintln!("Failed to read directory {}: {e}", dir.display());
+        process::exit(1);
+    });
+    let mut entries: Vec<_> = entries.filter_map(Result::ok).collect();
+    entries.sort_by_key(fs::DirEntry::path);
+    for entry in entries {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_hist_files(&path, out);
+        } else if path.extension().is_some_and(|e| e == "hist") {
+            out.push(path);
+        }
     }
 }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -15,8 +15,6 @@ hashbrown   = { workspace = true }
 serde       = { workspace = true, optional = true, features = [ "derive" ] }
 tracing     = { workspace = true }
 derive_more = { workspace = true }
-winnow      = { workspace = true, optional = true }
-logos       = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion   = { version = "0.8", features = [ "html_reports" ] }
@@ -29,7 +27,6 @@ workspace = true
 default      = [  ]
 serde        = [ "dep:serde", "hashbrown/serde" ]
 compact-serde = [ "serde" ]
-parser       = [ "dep:winnow", "dep:logos" ]
 
 [[bench]]
 name    = "consistency"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -15,16 +15,21 @@ hashbrown   = { workspace = true }
 serde       = { workspace = true, optional = true, features = [ "derive" ] }
 tracing     = { workspace = true }
 derive_more = { workspace = true }
+winnow      = { workspace = true, optional = true }
+logos       = { workspace = true, optional = true }
 
 [dev-dependencies]
-criterion = { version = "0.8", features = [ "html_reports" ] }
+criterion   = { version = "0.8", features = [ "html_reports" ] }
+serde_json  = { workspace = true }
 
 [lints]
 workspace = true
 
 [features]
-default = [  ]
-serde   = [ "dep:serde", "hashbrown/serde" ]
+default      = [  ]
+serde        = [ "dep:serde", "hashbrown/serde" ]
+compact-serde = [ "serde" ]
+parser       = [ "dep:winnow", "dep:logos" ]
 
 [[bench]]
 name    = "consistency"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -17,15 +17,15 @@ tracing     = { workspace = true }
 derive_more = { workspace = true }
 
 [dev-dependencies]
-criterion   = { version = "0.8", features = [ "html_reports" ] }
-serde_json  = { workspace = true }
+criterion  = { version = "0.8", features = [ "html_reports" ] }
+serde_json = { workspace = true }
 
 [lints]
 workspace = true
 
 [features]
-default      = [  ]
-serde        = [ "dep:serde", "hashbrown/serde" ]
+default       = [  ]
+serde         = [ "dep:serde", "hashbrown/serde" ]
 compact-serde = [ "serde" ]
 
 [[bench]]

--- a/crates/core/src/history/raw/display.rs
+++ b/crates/core/src/history/raw/display.rs
@@ -1,0 +1,72 @@
+use alloc::string::String;
+use core::fmt::Display;
+
+use crate::history::raw::types::Session;
+
+/// Format a complete history as the compact text DSL.
+///
+/// Sessions are separated by `---`. Each transaction is on its own line.
+/// The output always ends with a trailing newline so that it round-trips
+/// through `parse_history` without needing any external fixup.
+pub fn format_history<Variable, Version>(sessions: &[Session<Variable, Version>]) -> String
+where
+    Variable: Display,
+    Version: Display,
+{
+    let mut output = String::new();
+    for (i, session) in sessions.iter().enumerate() {
+        if i > 0 {
+            output.push_str("---\n");
+        }
+        for transaction in session {
+            output.push_str(&alloc::format!("{transaction}\n"));
+        }
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::history::raw::types::{Event, Transaction};
+
+    #[test]
+    fn test_format_history_single_session() {
+        let sessions = vec![vec![
+            Transaction::committed(vec![Event::write("x", 1), Event::write("y", 1)]),
+            Transaction::committed(vec![Event::read("z", 2), Event::write("z", 3)]),
+        ]];
+        let result = format_history(&sessions);
+        assert_eq!(result, "[x:=1 y:=1]\n[z==2 z:=3]\n");
+    }
+
+    #[test]
+    fn test_format_history_two_sessions() {
+        let sessions = vec![
+            vec![
+                Transaction::committed(vec![Event::write("x", 1), Event::write("y", 1)]),
+                Transaction::committed(vec![Event::read("z", 2), Event::write("z", 3)]),
+            ],
+            vec![Transaction::committed(vec![
+                Event::read("a", 1),
+                Event::write("b", 3),
+            ])],
+        ];
+        let result = format_history(&sessions);
+        assert_eq!(result, "[x:=1 y:=1]\n[z==2 z:=3]\n---\n[a==1 b:=3]\n");
+    }
+
+    #[test]
+    fn test_format_history_empty() {
+        let sessions: Vec<Session<&str, u64>> = vec![];
+        let result = format_history(&sessions);
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn test_format_history_uncommitted() {
+        let sessions = vec![vec![Transaction::uncommitted(vec![Event::write("x", 1)])]];
+        let result = format_history(&sessions);
+        assert_eq!(result, "[x:=1]!\n");
+    }
+}

--- a/crates/core/src/history/raw/display.rs
+++ b/crates/core/src/history/raw/display.rs
@@ -1,5 +1,5 @@
 use alloc::string::String;
-use core::fmt::Display;
+use core::fmt::{Display, Write};
 
 use crate::history::raw::types::Session;
 
@@ -8,6 +8,7 @@ use crate::history::raw::types::Session;
 /// Sessions are separated by `---`. Each transaction is on its own line.
 /// The output always ends with a trailing newline so that it round-trips
 /// through `parse_history` without needing any external fixup.
+#[must_use]
 pub fn format_history<Variable, Version>(sessions: &[Session<Variable, Version>]) -> String
 where
     Variable: Display,
@@ -19,7 +20,7 @@ where
             output.push_str("---\n");
         }
         for transaction in session {
-            output.push_str(&alloc::format!("{transaction}\n"));
+            let _ = writeln!(output, "{transaction}");
         }
     }
     output

--- a/crates/core/src/history/raw/lexer.rs
+++ b/crates/core/src/history/raw/lexer.rs
@@ -1,0 +1,265 @@
+//! Logos-based lexer for the compact history text DSL.
+//!
+//! The DSL describes transactional histories in a compact textual form.
+//! Sessions are separated by lines of dashes (`---`), transactions are
+//! enclosed in brackets (`[...]`), writes use `:=`, reads use `==`,
+//! `?` marks an uninitialized read, and `!` marks an uncommitted transaction.
+//!
+//! # Example input
+//!
+//! ```text
+//! // session 1
+//! [x:=1 y:=1] [z==2 z:=3]
+//! [y:=3]
+//! ---
+//! // session 2
+//! [a==1 b:=3] [c:=3]
+//! ```
+
+use alloc::vec::Vec;
+use core::ops::Range;
+
+/// All token kinds produced by the DSL lexer.
+#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+#[derive(::logos::Logos, Debug, Clone, PartialEq, Eq)]
+pub enum TokenKind {
+    /// A line comment starting with `//` and running to end of line.
+    #[regex(r"//[^\n]*")]
+    Comment,
+
+    /// One or more `-` characters on their own (session separator).
+    #[regex(r"-+")]
+    Dash,
+
+    /// Opening bracket `[`.
+    #[token("[")]
+    BracketOpen,
+
+    /// Closing bracket `]`.
+    #[token("]")]
+    BracketClose,
+
+    /// Write operator `:=`.
+    #[token(":=")]
+    ColonEquals,
+
+    /// Read operator `==`.
+    #[token("==")]
+    DoubleEquals,
+
+    /// Uninitialized read marker `?`.
+    #[token("?")]
+    QuestionMark,
+
+    /// Uncommitted transaction marker `!`.
+    #[token("!")]
+    Bang,
+
+    /// An identifier: starts with a letter or underscore, followed by
+    /// letters, digits, or underscores.
+    #[regex(r"[a-zA-Z_][a-zA-Z0-9_]*")]
+    Ident,
+
+    /// An integer literal: one or more ASCII digits.
+    #[regex(r"[0-9]+")]
+    Integer,
+
+    /// A newline (`\n` or `\r\n`).
+    #[regex(r"\r?\n")]
+    Newline,
+
+    /// Spaces or tabs. Emitted so the tokenizer can be used for syntax
+    /// highlighting where whitespace positioning matters.
+    #[regex(r"[ \t]+")]
+    Whitespace,
+}
+
+/// A single token with its kind and the byte-offset span in the source.
+#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Token {
+    /// What kind of token this is.
+    pub kind: TokenKind,
+    /// Byte range `start..end` into the original input string.
+    pub span: Range<usize>,
+}
+
+impl Token {
+    /// Construct a new [`Token`].
+    #[must_use]
+    pub const fn new(kind: TokenKind, span: Range<usize>) -> Self {
+        Self { kind, span }
+    }
+
+    /// Return the source text for this token given the original input.
+    #[must_use]
+    pub fn text<'a>(&self, input: &'a str) -> &'a str {
+        &input[self.span.clone()]
+    }
+}
+
+/// Tokenize `input` and return all valid tokens.
+///
+/// Tokens that the lexer cannot recognise are silently skipped.
+/// Use [`tokenize_with_text`] if you also need the source slice for each token.
+#[must_use]
+pub fn tokenize(input: &str) -> Vec<Token> {
+    use logos::Logos as _;
+    TokenKind::lexer(input)
+        .spanned()
+        .filter_map(|(result, span)| result.ok().map(|kind| Token { kind, span }))
+        .collect()
+}
+
+/// Tokenize `input` and return tokens paired with their source text slices.
+///
+/// Tokens that the lexer cannot recognise are silently skipped.
+#[must_use]
+pub fn tokenize_with_text(input: &str) -> Vec<(Token, &str)> {
+    use logos::Logos as _;
+    TokenKind::lexer(input)
+        .spanned()
+        .filter_map(|(result, span)| {
+            result.ok().map(|kind| {
+                let text = &input[span.clone()];
+                (Token { kind, span }, text)
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{tokenize, tokenize_with_text, TokenKind};
+
+    fn kinds(input: &str) -> Vec<TokenKind> {
+        tokenize(input).into_iter().map(|t| t.kind).collect()
+    }
+
+    #[test]
+    fn test_basic_history() {
+        let input = "[x:=1 y:=1]\n[z==2]\n";
+        let tokens = tokenize(input);
+        let expected_kinds = [
+            TokenKind::BracketOpen,
+            TokenKind::Ident, // x
+            TokenKind::ColonEquals,
+            TokenKind::Integer, // 1
+            TokenKind::Whitespace,
+            TokenKind::Ident, // y
+            TokenKind::ColonEquals,
+            TokenKind::Integer, // 1
+            TokenKind::BracketClose,
+            TokenKind::Newline,
+            TokenKind::BracketOpen,
+            TokenKind::Ident, // z
+            TokenKind::DoubleEquals,
+            TokenKind::Integer, // 2
+            TokenKind::BracketClose,
+            TokenKind::Newline,
+        ];
+        let got_kinds: Vec<_> = tokens.iter().map(|t| t.kind.clone()).collect();
+        assert_eq!(got_kinds, expected_kinds);
+    }
+
+    #[test]
+    fn test_comment_tokenization() {
+        let input = "// this is a comment\n[x:=1]\n";
+        let ks = kinds(input);
+        assert_eq!(ks[0], TokenKind::Comment);
+        assert_eq!(ks[1], TokenKind::Newline);
+        assert_eq!(ks[2], TokenKind::BracketOpen);
+    }
+
+    #[test]
+    fn test_separator_tokenization() {
+        let input = "---\n";
+        let ks = kinds(input);
+        assert_eq!(ks[0], TokenKind::Dash);
+        assert_eq!(ks[1], TokenKind::Newline);
+
+        // A single dash is also a valid Dash token.
+        let input2 = "-\n";
+        let ks2 = kinds(input2);
+        assert_eq!(ks2[0], TokenKind::Dash);
+
+        // Many dashes.
+        let input3 = "----------\n";
+        let ks3 = kinds(input3);
+        assert_eq!(ks3[0], TokenKind::Dash);
+    }
+
+    #[test]
+    fn test_operator_tokens() {
+        let input = ":= == ? !";
+        let ks = kinds(input);
+        assert_eq!(ks[0], TokenKind::ColonEquals);
+        assert_eq!(ks[1], TokenKind::Whitespace);
+        assert_eq!(ks[2], TokenKind::DoubleEquals);
+        assert_eq!(ks[3], TokenKind::Whitespace);
+        assert_eq!(ks[4], TokenKind::QuestionMark);
+        assert_eq!(ks[5], TokenKind::Whitespace);
+        assert_eq!(ks[6], TokenKind::Bang);
+    }
+
+    #[test]
+    fn test_tokenize_with_text_spans() {
+        let input = "[x:=42]";
+        let pairs = tokenize_with_text(input);
+        let texts: Vec<&str> = pairs.iter().map(|(_, s)| *s).collect();
+        assert_eq!(texts, &["[", "x", ":=", "42", "]"]);
+    }
+
+    #[test]
+    fn test_token_text_helper() {
+        let input = "abc:=99";
+        let tokens = tokenize(input);
+        assert_eq!(tokens[0].text(input), "abc");
+        assert_eq!(tokens[1].text(input), ":=");
+        assert_eq!(tokens[2].text(input), "99");
+    }
+
+    #[test]
+    fn test_full_example() {
+        let input = "// session 1\n[x:=1 y:=1] [z==2 z:=3]\n[y:=3]\n---\n// session 2\n[a==1 b:=3] [c:=3]\n";
+        let pairs = tokenize_with_text(input);
+        // First token is the comment.
+        assert_eq!(pairs[0].0.kind, TokenKind::Comment);
+        assert_eq!(pairs[0].1, "// session 1");
+        // Find the separator.
+        let sep = pairs.iter().find(|(t, _)| t.kind == TokenKind::Dash);
+        assert!(sep.is_some());
+        assert_eq!(sep.unwrap().1, "---");
+    }
+
+    #[test]
+    fn test_question_mark_and_bang() {
+        let input = "[x==? y:=1]!";
+        let ks = kinds(input);
+        assert!(ks.contains(&TokenKind::QuestionMark));
+        assert!(ks.contains(&TokenKind::Bang));
+    }
+
+    #[test]
+    fn test_integer_and_ident() {
+        let input = "foo_bar 123 _under";
+        let ks = kinds(input);
+        assert_eq!(ks[0], TokenKind::Ident); // foo_bar
+        assert_eq!(ks[1], TokenKind::Whitespace);
+        assert_eq!(ks[2], TokenKind::Integer); // 123
+        assert_eq!(ks[3], TokenKind::Whitespace);
+        assert_eq!(ks[4], TokenKind::Ident); // _under
+    }
+
+    #[test]
+    fn test_span_correctness() {
+        let input = "[abc]";
+        let tokens = tokenize(input);
+        // '[' at 0..1
+        assert_eq!(tokens[0].span, 0..1);
+        // 'abc' at 1..4
+        assert_eq!(tokens[1].span, 1..4);
+        // ']' at 4..5
+        assert_eq!(tokens[2].span, 4..5);
+    }
+}

--- a/crates/core/src/history/raw/mod.rs
+++ b/crates/core/src/history/raw/mod.rs
@@ -1,9 +1,5 @@
 pub mod display;
 pub mod error;
-#[cfg(feature = "parser")]
-pub mod lexer;
-#[cfg(feature = "parser")]
-pub mod parser;
 pub mod types;
 
 use ::core::hash::Hash;

--- a/crates/core/src/history/raw/mod.rs
+++ b/crates/core/src/history/raw/mod.rs
@@ -1,4 +1,9 @@
+pub mod display;
 pub mod error;
+#[cfg(feature = "parser")]
+pub mod lexer;
+#[cfg(feature = "parser")]
+pub mod parser;
 pub mod types;
 
 use ::core::hash::Hash;

--- a/crates/core/src/history/raw/parser.rs
+++ b/crates/core/src/history/raw/parser.rs
@@ -1,0 +1,489 @@
+/// Winnow-based parser for the compact history text DSL.
+///
+/// Grammar:
+/// ```text
+/// history      = session (separator session)*
+/// separator    = NEWLINE DASH+ NEWLINE
+/// session      = (comment | session_line)*
+/// comment      = "//" REST_OF_LINE NEWLINE
+/// session_line = transaction (WHITESPACE transaction)* NEWLINE
+/// transaction  = "[" event (WHITESPACE event)* "]" "!"?
+/// event        = variable ":=" version   -- write
+///              | variable "==" version   -- read (versioned)
+///              | variable "==?"          -- read (uninitialized)
+/// variable     = IDENT
+/// version      = INTEGER
+/// ```
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
+use winnow::ascii::{dec_uint, newline, till_line_ending};
+use winnow::combinator::{alt, opt, repeat, separated};
+use winnow::prelude::*;
+use winnow::token::{literal, take_while};
+use winnow::ModalResult;
+
+use crate::history::raw::types::{Event, Session, Transaction};
+
+// ---------------------------------------------------------------------------
+// Public error type
+// ---------------------------------------------------------------------------
+
+/// A parse error with human-readable location information.
+#[derive(Debug, Clone)]
+pub struct ParseError {
+    pub message: String,
+    pub line: usize,
+    pub column: usize,
+}
+
+impl core::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "parse error at line {}, column {}: {}",
+            self.line, self.column, self.message
+        )
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Parse a compact history DSL string into a list of sessions.
+///
+/// # Errors
+///
+/// Returns a [`ParseError`] with line/column information when the input does
+/// not conform to the grammar.
+pub fn parse_history(input: &str) -> Result<Vec<Session<String, u64>>, ParseError> {
+    let original = input;
+    let mut stream: &str = input;
+    match history_parser.parse_next(&mut stream) {
+        Ok(sessions) => Ok(sessions),
+        Err(e) => {
+            // Compute how many bytes were consumed before the error.
+            let remaining_len = stream.len();
+            let consumed = original.len().saturating_sub(remaining_len);
+            let (line, column) = offset_to_line_col(original, consumed);
+            Err(ParseError {
+                message: e.to_string(),
+                line,
+                column,
+            })
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Line/column helper
+// ---------------------------------------------------------------------------
+
+/// Convert a byte offset into the original input to 1-based (line, column).
+fn offset_to_line_col(input: &str, offset: usize) -> (usize, usize) {
+    let safe_offset = offset.min(input.len());
+    let prefix = &input[..safe_offset];
+    let line = prefix.bytes().filter(|&b| b == b'\n').count() + 1;
+    let column = match prefix.rfind('\n') {
+        Some(pos) => prefix.len() - pos,
+        None => prefix.len() + 1,
+    };
+    (line, column)
+}
+
+// ---------------------------------------------------------------------------
+// Whitespace helpers
+// ---------------------------------------------------------------------------
+
+/// Inline whitespace: spaces and tabs only (no newlines).
+fn inline_ws(input: &mut &str) -> ModalResult<()> {
+    take_while(1.., |c: char| c == ' ' || c == '\t')
+        .void()
+        .parse_next(input)
+}
+
+/// Optional inline whitespace.
+fn opt_inline_ws(input: &mut &str) -> ModalResult<()> {
+    take_while(0.., |c: char| c == ' ' || c == '\t')
+        .void()
+        .parse_next(input)
+}
+
+// ---------------------------------------------------------------------------
+// Leaf parsers
+// ---------------------------------------------------------------------------
+
+/// Parse an identifier: one or more alphanumeric characters (or `_`).
+fn variable(input: &mut &str) -> ModalResult<String> {
+    // alphanumeric1 matches [a-zA-Z0-9]+; we also allow underscore.
+    take_while(1.., |c: char| c.is_alphanumeric() || c == '_')
+        .map(|s: &str| s.to_string())
+        .parse_next(input)
+}
+
+/// Parse a non-negative integer version.
+fn version(input: &mut &str) -> ModalResult<u64> {
+    dec_uint.parse_next(input)
+}
+
+// ---------------------------------------------------------------------------
+// Event parsers
+// ---------------------------------------------------------------------------
+
+/// `variable ":=" version`  -- write event
+fn write_event(input: &mut &str) -> ModalResult<Event<String, u64>> {
+    let var = variable.parse_next(input)?;
+    literal(":=").parse_next(input)?;
+    let ver = version.parse_next(input)?;
+    Ok(Event::write(var, ver))
+}
+
+/// `variable "==?" `  -- uninitialized read event
+fn read_empty_event(input: &mut &str) -> ModalResult<Event<String, u64>> {
+    let var = variable.parse_next(input)?;
+    literal("==?").parse_next(input)?;
+    Ok(Event::read_empty(var))
+}
+
+/// `variable "==" version`  -- versioned read event
+fn read_event(input: &mut &str) -> ModalResult<Event<String, u64>> {
+    let var = variable.parse_next(input)?;
+    literal("==").parse_next(input)?;
+    let ver = version.parse_next(input)?;
+    Ok(Event::read(var, ver))
+}
+
+/// Any event: try write first, then uninitialized read (must come before
+/// versioned read because `==?` starts with `==`), then versioned read.
+fn event(input: &mut &str) -> ModalResult<Event<String, u64>> {
+    alt((write_event, read_empty_event, read_event)).parse_next(input)
+}
+
+// ---------------------------------------------------------------------------
+// Transaction parser
+// ---------------------------------------------------------------------------
+
+/// `"[" event (WS event)* "]" "!"?`
+///
+/// Trailing `!` marks the transaction as *uncommitted*.
+fn transaction(input: &mut &str) -> ModalResult<Transaction<String, u64>> {
+    literal("[").parse_next(input)?;
+    let events: Vec<Event<String, u64>> = separated(1.., event, inline_ws).parse_next(input)?;
+    literal("]").parse_next(input)?;
+    let bang = opt(literal("!")).parse_next(input)?;
+    let committed = bang.is_none();
+    if committed {
+        Ok(Transaction::committed(events))
+    } else {
+        Ok(Transaction::uncommitted(events))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Session-line and comment parsers
+// ---------------------------------------------------------------------------
+
+/// A comment line: `"//" <rest-of-line> NEWLINE`.
+/// Returns `None` (comments produce no transactions).
+fn comment_line(input: &mut &str) -> ModalResult<Option<Vec<Transaction<String, u64>>>> {
+    literal("//").parse_next(input)?;
+    till_line_ending.parse_next(input)?;
+    newline.parse_next(input)?;
+    Ok(None)
+}
+
+/// A session line: one or more transactions separated by inline whitespace,
+/// terminated by a newline.
+fn session_line(input: &mut &str) -> ModalResult<Option<Vec<Transaction<String, u64>>>> {
+    opt_inline_ws.parse_next(input)?;
+    let txns: Vec<Transaction<String, u64>> =
+        separated(1.., transaction, inline_ws).parse_next(input)?;
+    opt_inline_ws.parse_next(input)?;
+    newline.parse_next(input)?;
+    Ok(Some(txns))
+}
+
+/// A blank line (only whitespace + newline). Produces nothing.
+fn blank_line(input: &mut &str) -> ModalResult<Option<Vec<Transaction<String, u64>>>> {
+    opt_inline_ws.parse_next(input)?;
+    newline.parse_next(input)?;
+    Ok(None)
+}
+
+/// One item inside a session: comment, blank line, or transaction line.
+fn session_item(input: &mut &str) -> ModalResult<Option<Vec<Transaction<String, u64>>>> {
+    // A separator line (only dashes) must NOT be parsed as a session item;
+    // we detect it by peeking for '-' after optional whitespace.
+    alt((comment_line, blank_line, session_line)).parse_next(input)
+}
+
+// ---------------------------------------------------------------------------
+// Separator parser
+// ---------------------------------------------------------------------------
+
+/// A separator is a line consisting of one or more `-` characters (possibly
+/// surrounded by inline whitespace), terminated by a newline.
+fn separator(input: &mut &str) -> ModalResult<()> {
+    opt_inline_ws.parse_next(input)?;
+    take_while(1.., '-').parse_next(input)?;
+    opt_inline_ws.parse_next(input)?;
+    newline.parse_next(input)?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Session and history parsers
+// ---------------------------------------------------------------------------
+
+/// A session is zero or more session items (comments, blank lines, transaction
+/// lines) that appear *before* a separator or end-of-input.
+///
+/// We parse items one at a time; we stop when we see a separator prefix (`-`)
+/// or reach end-of-input.
+fn session(input: &mut &str) -> ModalResult<Session<String, u64>> {
+    let mut transactions: Vec<Transaction<String, u64>> = Vec::new();
+
+    loop {
+        // Peek: if next non-whitespace char is '-', this is a separator -- stop.
+        let trimmed = input.trim_start_matches([' ', '\t']);
+        if trimmed.starts_with('-') || trimmed.is_empty() {
+            break;
+        }
+        match session_item.parse_next(input)? {
+            Some(mut txns) => transactions.append(&mut txns),
+            None => {}
+        }
+    }
+
+    Ok(transactions)
+}
+
+/// The top-level history: `session (separator session)*` followed by optional
+/// trailing whitespace/newlines and end-of-input.
+fn history_parser(input: &mut &str) -> ModalResult<Vec<Session<String, u64>>> {
+    let first = session.parse_next(input)?;
+    let mut sessions = Vec::new();
+    sessions.push(first);
+
+    loop {
+        // Consume a separator if present.
+        if separator.parse_next(input).is_err() {
+            break;
+        }
+        let s = session.parse_next(input)?;
+        sessions.push(s);
+    }
+
+    // Consume any trailing blank lines / whitespace.
+    repeat::<_, _, (), _, _>(0.., blank_line).parse_next(input)?;
+
+    // Verify we are at end-of-input.
+    if !input.is_empty() {
+        // Return a backtrack error so the caller sees remaining input.
+        return Err(winnow::error::ErrMode::Backtrack(
+            winnow::error::ContextError::new(),
+        ));
+    }
+
+    Ok(sessions)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Shorthand constructors for tests.
+    fn w(var: &str, ver: u64) -> Event<String, u64> {
+        Event::write(var.to_string(), ver)
+    }
+    fn r(var: &str, ver: u64) -> Event<String, u64> {
+        Event::read(var.to_string(), ver)
+    }
+    fn re(var: &str) -> Event<String, u64> {
+        Event::read_empty(var.to_string())
+    }
+    fn _committed(events: Vec<Event<String, u64>>) -> Transaction<String, u64> {
+        Transaction::committed(events)
+    }
+    fn _uncommitted(events: Vec<Event<String, u64>>) -> Transaction<String, u64> {
+        Transaction::uncommitted(events)
+    }
+
+    // -----------------------------------------------------------------------
+    // Happy-path tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_single_session() {
+        let input = "[x:=1 y:=1]\n";
+        let result = parse_history(input).expect("should parse");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].len(), 1);
+        assert_eq!(result[0][0].events, vec![w("x", 1), w("y", 1)]);
+        assert!(result[0][0].committed);
+    }
+
+    #[test]
+    fn test_multi_session_with_separator() {
+        let input = "[x:=1]\n---\n[y:=2]\n";
+        let result = parse_history(input).expect("should parse");
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0][0].events, vec![w("x", 1)]);
+        assert_eq!(result[1][0].events, vec![w("y", 2)]);
+    }
+
+    #[test]
+    fn test_multiple_transactions_per_line() {
+        let input = "[x:=1 y:=1] [z==2 z:=3]\n[y:=3]\n";
+        let result = parse_history(input).expect("should parse");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].len(), 3);
+        assert_eq!(result[0][0].events, vec![w("x", 1), w("y", 1)]);
+        assert_eq!(result[0][1].events, vec![r("z", 2), w("z", 3)]);
+        assert_eq!(result[0][2].events, vec![w("y", 3)]);
+    }
+
+    #[test]
+    fn test_uncommitted_transaction() {
+        let input = "[x:=1]!\n";
+        let result = parse_history(input).expect("should parse");
+        assert!(!result[0][0].committed);
+        assert_eq!(result[0][0].events, vec![w("x", 1)]);
+    }
+
+    #[test]
+    fn test_uninitialized_read() {
+        let input = "[x==?]\n";
+        let result = parse_history(input).expect("should parse");
+        assert_eq!(result[0][0].events, vec![re("x")]);
+    }
+
+    #[test]
+    fn test_comments_are_skipped() {
+        let input = "// session 1\n[x:=1]\n---\n// session 2\n[y:=2]\n";
+        let result = parse_history(input).expect("should parse");
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0][0].events, vec![w("x", 1)]);
+        assert_eq!(result[1][0].events, vec![w("y", 2)]);
+    }
+
+    #[test]
+    fn test_empty_session_between_separators() {
+        let input = "[x:=1]\n---\n---\n[y:=2]\n";
+        let result = parse_history(input).expect("should parse");
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0].len(), 1);
+        assert_eq!(result[1].len(), 0); // empty session
+        assert_eq!(result[2].len(), 1);
+    }
+
+    #[test]
+    fn test_full_example() {
+        let input = "\
+// session 1
+[x:=1 y:=1] [z==2 z:=3]
+[y:=3]
+---
+// session 2
+[a==1 b:=3] [c:=3]
+[d==3]
+";
+        let result = parse_history(input).expect("should parse full example");
+        assert_eq!(result.len(), 2);
+
+        let s0 = &result[0];
+        assert_eq!(s0.len(), 3);
+        assert_eq!(s0[0].events, vec![w("x", 1), w("y", 1)]);
+        assert_eq!(s0[1].events, vec![r("z", 2), w("z", 3)]);
+        assert_eq!(s0[2].events, vec![w("y", 3)]);
+
+        let s1 = &result[1];
+        assert_eq!(s1.len(), 3);
+        assert_eq!(s1[0].events, vec![r("a", 1), w("b", 3)]);
+        assert_eq!(s1[1].events, vec![w("c", 3)]);
+        assert_eq!(s1[2].events, vec![r("d", 3)]);
+    }
+
+    #[test]
+    fn test_committed_and_uncommitted_mix() {
+        let input = "[x:=1] [y:=2]!\n";
+        let result = parse_history(input).expect("should parse");
+        assert!(result[0][0].committed);
+        assert!(!result[0][1].committed);
+    }
+
+    #[test]
+    fn test_multiple_events_in_transaction() {
+        let input = "[a:=1 b==2 c==? d:=5]\n";
+        let result = parse_history(input).expect("should parse");
+        assert_eq!(
+            result[0][0].events,
+            vec![w("a", 1), r("b", 2), re("c"), w("d", 5)]
+        );
+    }
+
+    #[test]
+    fn test_blank_lines_in_session() {
+        let input = "[x:=1]\n\n[y:=2]\n";
+        let result = parse_history(input).expect("should parse with blank lines");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].len(), 2);
+    }
+
+    #[test]
+    fn test_empty_history_single_session() {
+        // A history with no transactions at all.
+        let input = "// just a comment\n";
+        let result = parse_history(input).expect("should parse empty session");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].len(), 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // Error tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_error_has_line_column() {
+        // Invalid token at line 2, column 1.
+        let input = "[x:=1]\n@bad\n";
+        let err = parse_history(input).expect_err("should fail");
+        // The error should point to line 2.
+        assert_eq!(err.line, 2, "expected error on line 2, got: {err}");
+    }
+
+    #[test]
+    fn test_parse_error_display() {
+        let input = "[x:=1]\n@bad\n";
+        let err = parse_history(input).expect_err("should fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("parse error"),
+            "display should contain 'parse error': {msg}"
+        );
+        assert!(msg.contains("line"), "display should contain 'line': {msg}");
+    }
+
+    #[test]
+    fn test_offset_to_line_col_first_line() {
+        // Offset 0 on first line.
+        let (line, col) = offset_to_line_col("hello\nworld\n", 0);
+        assert_eq!(line, 1);
+        assert_eq!(col, 1);
+    }
+
+    #[test]
+    fn test_offset_to_line_col_second_line() {
+        // "hello\n" is 6 bytes; offset 6 is start of second line.
+        let (line, col) = offset_to_line_col("hello\nworld\n", 6);
+        assert_eq!(line, 2);
+        assert_eq!(col, 1);
+    }
+}

--- a/crates/core/src/history/raw/types.rs
+++ b/crates/core/src/history/raw/types.rs
@@ -45,14 +45,14 @@ where
         match self {
             Self::Read { variable, version } => {
                 let mut tup = serializer.serialize_tuple(3)?;
-                tup.serialize_element("r")?;
+                tup.serialize_element(&'r')?;
                 tup.serialize_element(variable)?;
                 tup.serialize_element(version)?;
                 tup.end()
             }
             Self::Write { variable, version } => {
                 let mut tup = serializer.serialize_tuple(3)?;
-                tup.serialize_element("w")?;
+                tup.serialize_element(&'w')?;
                 tup.serialize_element(variable)?;
                 tup.serialize_element(version)?;
                 tup.end()
@@ -94,7 +94,7 @@ where
             where
                 A: SeqAccess<'de>,
             {
-                let tag: &str = seq
+                let tag: char = seq
                     .next_element()?
                     .ok_or_else(|| de::Error::invalid_length(0, &"3"))?;
                 let variable: V = seq
@@ -102,19 +102,21 @@ where
                     .ok_or_else(|| de::Error::invalid_length(1, &"3"))?;
 
                 match tag {
-                    "r" => {
+                    'r' => {
                         let version: Option<W> = seq
                             .next_element()?
                             .ok_or_else(|| de::Error::invalid_length(2, &"3"))?;
                         Ok(Event::Read { variable, version })
                     }
-                    "w" => {
+                    'w' => {
                         let version: W = seq
                             .next_element()?
                             .ok_or_else(|| de::Error::invalid_length(2, &"3"))?;
                         Ok(Event::Write { variable, version })
                     }
-                    other => Err(de::Error::unknown_variant(other, &["r", "w"])),
+                    other => Err(de::Error::custom(alloc::format!(
+                        "unknown tag '{other}', expected 'r' or 'w'"
+                    ))),
                 }
             }
 

--- a/crates/core/src/history/raw/types.rs
+++ b/crates/core/src/history/raw/types.rs
@@ -1,10 +1,21 @@
+#[cfg(feature = "serde")]
+use alloc::string::String;
 use alloc::vec::Vec;
-use core::fmt::{Debug, Formatter, Result};
+use core::fmt::{self, Debug, Display, Formatter};
 
 use crate::history::atomic::types::TransactionId;
 
 /// A single read or write operation within a transaction.
-#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+///
+/// Serialization format depends on features:
+/// - Default (`serde`): tagged enum `{"Read": {"variable": ..., "version": ...}}`
+/// - Compact (`compact-serde`): tuple `["r", variable, version]` / `["w", variable, version]`
+///
+/// Deserialization always accepts both formats (backward-compatible).
+#[cfg_attr(
+    all(feature = "serde", not(feature = "compact-serde")),
+    derive(::serde::Serialize)
+)]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Event<Variable, Version> {
     Read {
@@ -16,6 +27,138 @@ pub enum Event<Variable, Version> {
         variable: Variable,
         version: Version,
     },
+}
+
+// -- Compact Serialize (feature = "compact-serde") ----------------------------
+
+#[cfg(feature = "compact-serde")]
+impl<Variable, Version> ::serde::Serialize for Event<Variable, Version>
+where
+    Variable: ::serde::Serialize,
+    Version: ::serde::Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ::serde::Serializer,
+    {
+        use ::serde::ser::SerializeTuple;
+        match self {
+            Self::Read { variable, version } => {
+                let mut tup = serializer.serialize_tuple(3)?;
+                tup.serialize_element("r")?;
+                tup.serialize_element(variable)?;
+                tup.serialize_element(version)?;
+                tup.end()
+            }
+            Self::Write { variable, version } => {
+                let mut tup = serializer.serialize_tuple(3)?;
+                tup.serialize_element("w")?;
+                tup.serialize_element(variable)?;
+                tup.serialize_element(version)?;
+                tup.end()
+            }
+        }
+    }
+}
+
+// -- Backward-compatible Deserialize (feature = "serde") ----------------------
+// Accepts both tagged-enum format and compact tuple format.
+
+#[cfg(feature = "serde")]
+impl<'de, Variable, Version> ::serde::Deserialize<'de> for Event<Variable, Version>
+where
+    Variable: ::serde::Deserialize<'de>,
+    Version: ::serde::Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: ::serde::Deserializer<'de>,
+    {
+        use ::serde::de::{self, MapAccess, SeqAccess, Visitor};
+
+        struct EventVisitor<V, W>(core::marker::PhantomData<(V, W)>);
+
+        impl<'de, V, W> Visitor<'de> for EventVisitor<V, W>
+        where
+            V: ::serde::Deserialize<'de>,
+            W: ::serde::Deserialize<'de>,
+        {
+            type Value = Event<V, W>;
+
+            fn expecting(&self, f: &mut Formatter) -> fmt::Result {
+                f.write_str("an Event as tagged enum or compact tuple [\"r\"/\"w\", var, ver]")
+            }
+
+            // Compact tuple: ["r", variable, version] or ["w", variable, version]
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let tag: &str = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(0, &"3"))?;
+                let variable: V = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(1, &"3"))?;
+
+                match tag {
+                    "r" => {
+                        let version: Option<W> = seq
+                            .next_element()?
+                            .ok_or_else(|| de::Error::invalid_length(2, &"3"))?;
+                        Ok(Event::Read { variable, version })
+                    }
+                    "w" => {
+                        let version: W = seq
+                            .next_element()?
+                            .ok_or_else(|| de::Error::invalid_length(2, &"3"))?;
+                        Ok(Event::Write { variable, version })
+                    }
+                    other => Err(de::Error::unknown_variant(other, &["r", "w"])),
+                }
+            }
+
+            // Tagged enum: {"Read": {...}} or {"Write": {...}}
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let key: String = map
+                    .next_key()?
+                    .ok_or_else(|| de::Error::custom("expected Read or Write key"))?;
+
+                match key.as_str() {
+                    "Read" => {
+                        #[derive(::serde::Deserialize)]
+                        struct ReadFields<V, W> {
+                            variable: V,
+                            version: Option<W>,
+                        }
+                        let fields: ReadFields<V, W> = map.next_value()?;
+                        Ok(Event::Read {
+                            variable: fields.variable,
+                            version: fields.version,
+                        })
+                    }
+                    "Write" => {
+                        #[derive(::serde::Deserialize)]
+                        struct WriteFields<V, W> {
+                            variable: V,
+                            version: W,
+                        }
+                        let fields: WriteFields<V, W> = map.next_value()?;
+                        Ok(Event::Write {
+                            variable: fields.variable,
+                            version: fields.version,
+                        })
+                    }
+                    other => Err(de::Error::unknown_variant(other, &["Read", "Write"])),
+                }
+            }
+        }
+
+        deserializer.deserialize_any(EventVisitor(core::marker::PhantomData))
+    }
 }
 
 impl<Variable, Version> Event<Variable, Version>
@@ -44,7 +187,7 @@ where
     Variable: Debug,
     Version: Debug,
 {
-    fn fmt(&self, f: &mut Formatter) -> Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
             Self::Read { variable, version } => {
                 write!(f, "{variable:?}=>")?;
@@ -87,8 +230,48 @@ where
     Variable: Debug,
     Version: Debug,
 {
-    fn fmt(&self, f: &mut Formatter) -> Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{:?}", self.events)?;
+        if !self.committed {
+            write!(f, "!")?;
+        }
+        Ok(())
+    }
+}
+
+impl<Variable, Version> Display for Event<Variable, Version>
+where
+    Variable: Display,
+    Version: Display,
+{
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            Self::Write { variable, version } => write!(f, "{variable}:={version}"),
+            Self::Read { variable, version } => {
+                if let Some(version) = version {
+                    write!(f, "{variable}=={version}")
+                } else {
+                    write!(f, "{variable}==?")
+                }
+            }
+        }
+    }
+}
+
+impl<Variable, Version> Display for Transaction<Variable, Version>
+where
+    Variable: Display,
+    Version: Display,
+{
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "[")?;
+        for (i, event) in self.events.iter().enumerate() {
+            if i > 0 {
+                write!(f, " ")?;
+            }
+            write!(f, "{event}")?;
+        }
+        write!(f, "]")?;
         if !self.committed {
             write!(f, "!")?;
         }
@@ -206,5 +389,90 @@ mod tests {
         assert_eq!(format!("{transaction:?}"), "[1=>?, 1<=2]");
         transaction.committed = false;
         assert_eq!(format!("{transaction:?}"), "[1=>?, 1<=2]!");
+    }
+
+    #[test]
+    fn test_event_display() {
+        assert_eq!(format!("{}", Event::<&str, u64>::write("x", 1)), "x:=1");
+        assert_eq!(format!("{}", Event::<&str, u64>::read("x", 1)), "x==1");
+        assert_eq!(format!("{}", Event::<&str, u64>::read_empty("x")), "x==?");
+    }
+
+    #[test]
+    fn test_transaction_display() {
+        let txn = Transaction::committed(vec![Event::write("x", 1), Event::read("y", 2)]);
+        assert_eq!(format!("{txn}"), "[x:=1 y==2]");
+        let txn = Transaction::uncommitted(vec![Event::write("x", 1)]);
+        assert_eq!(format!("{txn}"), "[x:=1]!");
+    }
+
+    // -- Serde tests ----------------------------------------------------------
+
+    /// Deserialize from tagged-enum JSON (the default serde format).
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde_tagged_roundtrip() {
+        let event: Event<u64, u64> = Event::write(0, 1);
+        let json = serde_json::to_string(&event).unwrap();
+        let back: Event<u64, u64> = serde_json::from_str(&json).unwrap();
+        assert_eq!(event, back);
+
+        let read_event: Event<u64, u64> = Event::read(0, 42);
+        let json = serde_json::to_string(&read_event).unwrap();
+        let back: Event<u64, u64> = serde_json::from_str(&json).unwrap();
+        assert_eq!(read_event, back);
+
+        let empty: Event<u64, u64> = Event::read_empty(0);
+        let json = serde_json::to_string(&empty).unwrap();
+        let back: Event<u64, u64> = serde_json::from_str(&json).unwrap();
+        assert_eq!(empty, back);
+    }
+
+    /// Deserialize compact tuple format even when compiled without compact-serde.
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde_deserialize_compact_tuple() {
+        // Write: ["w", variable, version]
+        let json = r#"["w", 0, 1]"#;
+        let event: Event<u64, u64> = serde_json::from_str(json).unwrap();
+        assert_eq!(event, Event::write(0, 1));
+
+        // Read: ["r", variable, version]
+        let json = r#"["r", 0, 42]"#;
+        let event: Event<u64, u64> = serde_json::from_str(json).unwrap();
+        assert_eq!(event, Event::read(0, 42));
+
+        // Read empty: ["r", variable, null]
+        let json = r#"["r", 0, null]"#;
+        let event: Event<u64, u64> = serde_json::from_str(json).unwrap();
+        assert_eq!(event, Event::read_empty(0));
+    }
+
+    /// Deserialize tagged-enum format always works.
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde_deserialize_tagged_enum() {
+        let json = r#"{"Write":{"variable":0,"version":1}}"#;
+        let event: Event<u64, u64> = serde_json::from_str(json).unwrap();
+        assert_eq!(event, Event::write(0, 1));
+
+        let json = r#"{"Read":{"variable":0,"version":42}}"#;
+        let event: Event<u64, u64> = serde_json::from_str(json).unwrap();
+        assert_eq!(event, Event::read(0, 42));
+
+        let json = r#"{"Read":{"variable":0,"version":null}}"#;
+        let event: Event<u64, u64> = serde_json::from_str(json).unwrap();
+        assert_eq!(event, Event::read_empty(0));
+    }
+
+    /// Transaction serde roundtrip.
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde_transaction_roundtrip() {
+        let txn = Transaction::committed(vec![Event::write(0u64, 1u64), Event::read(1, 2)]);
+        let json = serde_json::to_string(&txn).unwrap();
+        let back: Transaction<u64, u64> = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.events, txn.events);
+        assert_eq!(back.committed, txn.committed);
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -43,11 +43,14 @@
 //!
 //! - **`serde`** -- enables `Serialize`/`Deserialize` derives on core types
 //!   (`DiGraph`, `TransactionId`, `Consistency`, `Witness`, `Error`).
+//! - **`parser`** -- enables the compact text DSL parser and lexer (requires
+//!   `std`). Adds `winnow` and `logos` dependencies.
 //!
-//! This crate is `no_std` compatible (requires `alloc`).
+//! This crate is `no_std` compatible (requires `alloc`) when the `parser`
+//! feature is not enabled.
 
-#![cfg_attr(not(test), no_std)]
-#![cfg_attr(not(test), no_main)]
+#![cfg_attr(not(any(test, feature = "parser")), no_std)]
+#![cfg_attr(not(any(test, feature = "parser")), no_main)]
 extern crate alloc;
 
 pub mod consistency;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -43,14 +43,12 @@
 //!
 //! - **`serde`** -- enables `Serialize`/`Deserialize` derives on core types
 //!   (`DiGraph`, `TransactionId`, `Consistency`, `Witness`, `Error`).
-//! - **`parser`** -- enables the compact text DSL parser and lexer (requires
-//!   `std`). Adds `winnow` and `logos` dependencies.
 //!
-//! This crate is `no_std` compatible (requires `alloc`) when the `parser`
-//! feature is not enabled.
+//! This crate is `no_std` compatible (requires `alloc`). The parser and lexer
+//! live in the separate `dbcop_parser` crate.
 
-#![cfg_attr(not(any(test, feature = "parser")), no_std)]
-#![cfg_attr(not(any(test, feature = "parser")), no_main)]
+#![cfg_attr(not(test), no_std)]
+#![cfg_attr(not(test), no_main)]
 extern crate alloc;
 
 pub mod consistency;

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -12,11 +12,11 @@ rust-version.workspace = true
 [dependencies]
 dbcop_core = { workspace = true }
 winnow     = { workspace = true }
-logos       = { workspace = true }
+logos      = { workspace = true }
 serde      = { workspace = true, optional = true, features = [ "derive" ] }
 
 [features]
-default = []
+default = [  ]
 serde   = [ "dep:serde", "dbcop_core/serde" ]
 
 [dev-dependencies]

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name                   = "dbcop_parser"
+version.workspace      = true
+description.workspace  = true
+license.workspace      = true
+repository.workspace   = true
+keywords.workspace     = true
+categories.workspace   = true
+edition.workspace      = true
+rust-version.workspace = true
+
+[dependencies]
+dbcop_core = { workspace = true }
+winnow     = { workspace = true }
+logos       = { workspace = true }
+serde      = { workspace = true, optional = true, features = [ "derive" ] }
+
+[features]
+default = []
+serde   = [ "dep:serde", "dbcop_core/serde" ]
+
+[dev-dependencies]
+serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -8,6 +8,7 @@ keywords.workspace     = true
 categories.workspace   = true
 edition.workspace      = true
 rust-version.workspace = true
+readme                 = "README.md"
 
 [dependencies]
 dbcop_core = { workspace = true }

--- a/crates/parser/src/lexer.rs
+++ b/crates/parser/src/lexer.rs
@@ -16,7 +16,6 @@
 //! [a==1 b:=3] [c:=3]
 //! ```
 
-use alloc::vec::Vec;
 use core::ops::Range;
 
 /// All token kinds produced by the DSL lexer.

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod lexer;
+pub mod parser;
+
+pub use lexer::{tokenize, tokenize_with_text, Token, TokenKind};
+pub use parser::{parse_history, ParseError};

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -14,7 +14,7 @@ readme                 = "README.md"
 crate-type = [ "cdylib" ]
 
 [dependencies]
-dbcop_core   = { workspace = true, features = [ "serde" ] }
+dbcop_core   = { workspace = true, features = [ "serde", "parser" ] }
 wasm-bindgen = { workspace = true }
 serde        = { workspace = true, features = [ "derive" ] }
 serde_json   = { workspace = true, features = [ "alloc" ] }

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -14,7 +14,8 @@ readme                 = "README.md"
 crate-type = [ "cdylib" ]
 
 [dependencies]
-dbcop_core   = { workspace = true, features = [ "serde", "parser" ] }
+dbcop_core   = { workspace = true, features = [ "serde" ] }
+dbcop_parser = { workspace = true }
 wasm-bindgen = { workspace = true }
 serde        = { workspace = true, features = [ "derive" ] }
 serde_json   = { workspace = true, features = [ "alloc" ] }

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -230,7 +230,7 @@ pub fn check_consistency_trace(history_json: &str, level: &str) -> String {
 #[must_use]
 #[wasm_bindgen]
 pub fn parse_history_text(text: &str) -> String {
-    match dbcop_core::history::raw::parser::parse_history(text) {
+    match dbcop_parser::parse_history(text) {
         Ok(sessions) => serde_json::to_string(&sessions)
             .unwrap_or_else(|e| serde_json::json!({"error": e.to_string()}).to_string()),
         Err(e) => serde_json::json!({"error": e.to_string()}).to_string(),
@@ -248,7 +248,7 @@ pub fn check_consistency_trace_text(text: &str, level: &str) -> String {
         return serde_json::json!({"ok": false, "error": "unknown consistency level"}).to_string();
     };
 
-    let sessions = match dbcop_core::history::raw::parser::parse_history(text) {
+    let sessions = match dbcop_parser::parse_history(text) {
         Ok(s) => s,
         Err(e) => {
             return serde_json::json!({"ok": false, "error": e.to_string()}).to_string();
@@ -303,7 +303,7 @@ pub fn check_consistency_trace_text(text: &str, level: &str) -> String {
 #[must_use]
 #[wasm_bindgen]
 pub fn tokenize_history(text: &str) -> String {
-    let tokens = dbcop_core::history::raw::lexer::tokenize(text);
+    let tokens = dbcop_parser::tokenize(text);
     let result: Vec<serde_json::Value> = tokens
         .iter()
         .map(|t| {

--- a/web/index.html
+++ b/web/index.html
@@ -16,44 +16,72 @@
     ></script>
   </head>
   <body>
-    <header>
-      <h1>dbcop</h1>
-      <p>Transactional Consistency Checker</p>
-    </header>
-    <main>
-      <section id="input-section">
-        <h2>History Input</h2>
-        <select id="example-select">
-          <option value="write-read">Write-Read (PASS)</option>
-          <option value="lost-update">Lost Update (SI FAIL)</option>
-          <option value="serializable">Serializable History (PASS)</option>
-          <option value="causal-violation">Causal Violation</option>
-        </select>
-        <textarea
-          id="history-json"
-          rows="12"
-          placeholder="Enter history JSON..."
-        ></textarea>
-        <select id="level-select">
-          <option value="committed-read">Read Committed</option>
-          <option value="atomic-read">Atomic Read</option>
-          <option value="causal">Causal Consistency</option>
-          <option value="prefix">Prefix Consistency</option>
-          <option value="snapshot-isolation">Snapshot Isolation</option>
-          <option value="serializable" selected>Serializability</option>
-        </select>
-        <button id="check-btn">Check Consistency</button>
-      </section>
-      <section id="result-section">
-        <h2>Result</h2>
-        <div id="result-output">Run a check to see results.</div>
-      </section>
-      <section id="graph-section">
-        <h2>Transaction Graph</h2>
-        <div id="graph-container"></div>
-        <div id="legend"></div>
-      </section>
-    </main>
+    <div class="app">
+      <header>
+        <div class="title">
+          <h1>dbcop</h1>
+          <span class="subtitle">Transactional Consistency Checker</span>
+        </div>
+        <div class="header-actions">
+          <button class="theme-toggle" id="theme-toggle" title="Toggle theme">
+            &#9790;
+          </button>
+        </div>
+      </header>
+      <main>
+        <aside class="sidebar">
+          <div class="sidebar-section">
+            <h2>Example</h2>
+            <select id="example-select">
+              <option value="write-read">Write-Read (PASS)</option>
+              <option value="lost-update">Lost Update (SI FAIL)</option>
+              <option value="serializable">Serializable History (PASS)</option>
+              <option value="causal-violation">Causal Violation</option>
+            </select>
+          </div>
+          <div class="sidebar-section">
+            <h2>History Input</h2>
+            <div class="format-toggle">
+              <button id="fmt-text" class="active">Text</button>
+              <button id="fmt-json">JSON</button>
+            </div>
+            <div class="editor-wrap">
+              <textarea
+                id="history-input"
+                rows="12"
+                spellcheck="false"
+                placeholder="Enter history..."
+              ></textarea>
+              <div class="highlight-overlay" id="highlight-overlay"></div>
+            </div>
+          </div>
+          <div class="sidebar-section">
+            <h2>Consistency Level</h2>
+            <select id="level-select">
+              <option value="committed-read">Read Committed</option>
+              <option value="atomic-read">Atomic Read</option>
+              <option value="causal">Causal Consistency</option>
+              <option value="prefix">Prefix Consistency</option>
+              <option value="snapshot-isolation">Snapshot Isolation</option>
+              <option value="serializable" selected>Serializability</option>
+            </select>
+            <button class="check-btn" id="check-btn">Check Consistency</button>
+          </div>
+        </aside>
+        <div class="content">
+          <div class="result-bar" id="result-bar">
+            <span class="result-placeholder">Run a check to see results.</span>
+          </div>
+          <div class="sessions-panel">
+            <div class="sessions-container" id="sessions-display"></div>
+          </div>
+          <div class="graph-panel">
+            <div id="graph-container"></div>
+            <div id="legend"></div>
+          </div>
+        </div>
+      </main>
+    </div>
     <script type="module" src="main.ts"></script>
   </body>
 </html>

--- a/web/main.ts
+++ b/web/main.ts
@@ -1,35 +1,104 @@
-import { check_consistency_trace } from "../wasmlib/dbcop_wasm.js";
+import {
+  check_consistency_trace,
+  check_consistency_trace_text,
+  tokenize_history,
+} from "../wasmlib/dbcop_wasm.js";
 
 // deno-lint-ignore no-explicit-any
 declare const cytoscape: any;
 
-// -- Example histories -------------------------------------------------------
+// -- Types ------------------------------------------------------------------
 
-const EXAMPLES: Record<string, { history: unknown[]; level: string }> = {
+interface TransactionId {
+  session_id: number;
+  session_height: number;
+}
+
+interface SessionTransaction {
+  id: TransactionId;
+  reads: Record<string, number | null>;
+  writes: Record<string, number>;
+  committed: boolean;
+}
+
+interface TraceResult {
+  ok: boolean;
+  level?: string;
+  session_count?: number;
+  transaction_count?: number;
+  sessions?: SessionTransaction[][];
+  witness?: Record<string, unknown>;
+  witness_edges?: [TransactionId, TransactionId][];
+  wr_edges?: [TransactionId, TransactionId][];
+  error?: unknown;
+}
+
+interface HighlightToken {
+  kind: string;
+  start: number;
+  end: number;
+  text: string;
+}
+
+// -- Example histories (text DSL) -------------------------------------------
+
+const TEXT_EXAMPLES: Record<string, { text: string; level: string }> = {
   "write-read": {
     level: "serializable",
-    history: [
+    text: `// session 1: write then read
+[x:=1] [x==1]
+---
+// session 2: concurrent write
+[x:=2]`,
+  },
+  "lost-update": {
+    level: "snapshot-isolation",
+    text: `// session 1: read-then-write
+[x==0 x:=1]
+---
+// session 2: read-then-write (lost update)
+[x==0 x:=2]`,
+  },
+  serializable: {
+    level: "serializable",
+    text: `// session 1: write both
+[x:=1 y:=1]
+---
+// session 2: read x, write y
+[x==1 y:=2]
+---
+// session 3: read y
+[y==2]`,
+  },
+  "causal-violation": {
+    level: "causal",
+    text: `// session 1: write x and y
+[x:=1 y:=1]
+---
+// session 2: sees x, writes y
+[x==1 y:=2]
+---
+// session 3: sees y:=2 but not x:=1 (causal violation)
+[y==2 x==?]`,
+  },
+};
+
+const JSON_EXAMPLES: Record<string, { json: unknown[]; level: string }> = {
+  "write-read": {
+    level: "serializable",
+    json: [
       [
-        {
-          events: [{ Write: { variable: 0, version: 1 } }],
-          committed: true,
-        },
-        {
-          events: [{ Read: { variable: 0, version: 1 } }],
-          committed: true,
-        },
+        { events: [{ Write: { variable: 0, version: 1 } }], committed: true },
+        { events: [{ Read: { variable: 0, version: 1 } }], committed: true },
       ],
       [
-        {
-          events: [{ Write: { variable: 0, version: 2 } }],
-          committed: true,
-        },
+        { events: [{ Write: { variable: 0, version: 2 } }], committed: true },
       ],
     ],
   },
   "lost-update": {
     level: "snapshot-isolation",
-    history: [
+    json: [
       [
         {
           events: [
@@ -52,7 +121,7 @@ const EXAMPLES: Record<string, { history: unknown[]; level: string }> = {
   },
   serializable: {
     level: "serializable",
-    history: [
+    json: [
       [
         {
           events: [
@@ -81,7 +150,7 @@ const EXAMPLES: Record<string, { history: unknown[]; level: string }> = {
   },
   "causal-violation": {
     level: "causal",
-    history: [
+    json: [
       [
         {
           events: [
@@ -113,38 +182,68 @@ const EXAMPLES: Record<string, { history: unknown[]; level: string }> = {
   },
 };
 
-// -- Types for WASM result ---------------------------------------------------
+// -- State ------------------------------------------------------------------
 
-interface TransactionId {
-  session_id: number;
-  session_height: number;
-}
-
-interface SessionTransaction {
-  id: TransactionId;
-  reads: Record<string, number>;
-  writes: Record<string, number>;
-  committed: boolean;
-}
-
-interface TraceResult {
-  ok: boolean;
-  level?: string;
-  session_count?: number;
-  transaction_count?: number;
-  sessions?: SessionTransaction[][];
-  witness?: Record<string, unknown>;
-  witness_edges?: [TransactionId, TransactionId][];
-  wr_edges?: [TransactionId, TransactionId][];
-  error?: unknown;
-}
-
-// -- Graph state -------------------------------------------------------------
-
+let currentFormat: "text" | "json" = "text";
 // deno-lint-ignore no-explicit-any
 let cy: any = null;
 
-// -- Rendering ---------------------------------------------------------------
+// -- Theme ------------------------------------------------------------------
+
+function getThemeColors() {
+  const s = getComputedStyle(document.documentElement);
+  return {
+    bg: s.getPropertyValue("--bg").trim(),
+    text: s.getPropertyValue("--text").trim(),
+    muted: s.getPropertyValue("--muted").trim(),
+    border: s.getPropertyValue("--border").trim(),
+    nodeCommitted: s.getPropertyValue("--node-committed").trim(),
+    nodeUncommitted: s.getPropertyValue("--node-uncommitted").trim(),
+    edgeWr: s.getPropertyValue("--edge-wr").trim(),
+    edgeCo: s.getPropertyValue("--edge-co").trim(),
+    edgeSo: s.getPropertyValue("--edge-so").trim(),
+  };
+}
+
+function applyTheme(theme: "dark" | "light") {
+  if (theme === "light") {
+    document.documentElement.dataset.theme = "light";
+  } else {
+    delete document.documentElement.dataset.theme;
+  }
+  localStorage.setItem("theme", theme);
+
+  const btn = document.getElementById("theme-toggle")!;
+  btn.innerHTML = theme === "dark" ? "&#9790;" : "&#9728;";
+
+  // Re-theme cytoscape if active
+  if (cy) {
+    reThemeCytoscape();
+  }
+}
+
+function initTheme() {
+  const saved = localStorage.getItem("theme");
+  if (saved === "light" || saved === "dark") {
+    applyTheme(saved);
+  } else if (
+    globalThis.matchMedia &&
+    globalThis.matchMedia("(prefers-color-scheme: light)").matches
+  ) {
+    applyTheme("light");
+  } else {
+    applyTheme("dark");
+  }
+}
+
+function toggleTheme() {
+  const current = document.documentElement.dataset.theme === "light"
+    ? "light"
+    : "dark";
+  applyTheme(current === "dark" ? "light" : "dark");
+}
+
+// -- Helpers ----------------------------------------------------------------
 
 function txId(t: TransactionId): string {
   return "S" + t.session_id + "T" + t.session_height;
@@ -157,33 +256,173 @@ function txLabel(tx: SessionTransaction): string {
   const writes = Object.entries(tx.writes);
   if (writes.length > 0) {
     parts.push(
-      "W:" + writes.map(([v, ver]) => "x" + v + "=" + ver).join(","),
+      "W:" + writes.map(([v, ver]) => v + ":=" + ver).join(", "),
     );
   }
 
   const reads = Object.entries(tx.reads);
   if (reads.length > 0) {
     parts.push(
-      "R:" + reads.map(([v, ver]) => "x" + v + "=" + ver).join(","),
+      "R:" +
+        reads
+          .map(([v, ver]) => v + "==" + (ver === null ? "?" : ver))
+          .join(", "),
     );
   }
 
   return parts.join("\n");
 }
 
-function renderResult(
-  result: TraceResult,
-  container: HTMLElement,
-): void {
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+// -- Syntax highlighting ----------------------------------------------------
+
+function highlightText(text: string, overlay: HTMLElement) {
+  if (currentFormat !== "text") {
+    overlay.innerHTML = "";
+    return;
+  }
+
+  try {
+    const raw = tokenize_history(text);
+    const tokens: HighlightToken[] = JSON.parse(raw);
+    let html = "";
+    let pos = 0;
+
+    for (const tok of tokens) {
+      // Gap between tokens (shouldn't happen often)
+      if (tok.start > pos) {
+        html += escapeHtml(text.slice(pos, tok.start));
+      }
+
+      const escaped = escapeHtml(tok.text);
+      const cls = tokenClass(tok.kind);
+      if (cls) {
+        html += `<span class="${cls}">${escaped}</span>`;
+      } else {
+        html += escaped;
+      }
+      pos = tok.end;
+    }
+
+    // Remaining text after last token
+    if (pos < text.length) {
+      html += escapeHtml(text.slice(pos));
+    }
+
+    overlay.innerHTML = html;
+  } catch {
+    overlay.innerHTML = "";
+  }
+}
+
+function tokenClass(kind: string): string | null {
+  switch (kind) {
+    case "Comment":
+      return "syn-comment";
+    case "BracketOpen":
+    case "BracketClose":
+      return "syn-bracket";
+    case "ColonEquals":
+    case "DoubleEquals":
+      return "syn-operator";
+    case "Ident":
+      return "syn-variable";
+    case "Integer":
+      return "syn-number";
+    case "Dash":
+      return "syn-separator";
+    case "Bang":
+      return "syn-bang";
+    case "QuestionMark":
+      return "syn-question";
+    default:
+      return null;
+  }
+}
+
+// -- Session visualization --------------------------------------------------
+
+function renderSessions(result: TraceResult) {
+  const container = document.getElementById("sessions-display")!;
   container.innerHTML = "";
 
-  if (typeof result.error === "string") {
-    const heading = document.createElement("div");
-    heading.className = "result-fail";
-    heading.textContent = "ERROR";
-    container.appendChild(heading);
+  if (!result.sessions || result.sessions.length === 0) {
+    container.innerHTML =
+      '<span style="color:var(--muted);font-size:0.85rem">No session data.</span>';
+    return;
+  }
 
-    const detail = document.createElement("div");
+  for (let si = 0; si < result.sessions.length; si++) {
+    const session = result.sessions[si];
+    // Skip the "init" session (session_id === 0)
+    if (session.length > 0 && session[0].id.session_id === 0) continue;
+
+    const col = document.createElement("div");
+    col.className = "session-column";
+
+    const header = document.createElement("div");
+    header.className = "session-header";
+    header.textContent = "Session " + (si + 1);
+    col.appendChild(header);
+
+    for (const tx of session) {
+      const card = document.createElement("div");
+      card.className = "txn-card" + (tx.committed ? "" : " uncommitted");
+
+      const cardHeader = document.createElement("div");
+      cardHeader.className = "txn-card-header";
+      cardHeader.textContent = txId(tx.id) +
+        (tx.committed ? "" : " (uncommitted)");
+      card.appendChild(cardHeader);
+
+      // Render events: writes first, then reads
+      for (const [variable, version] of Object.entries(tx.writes)) {
+        const row = document.createElement("div");
+        row.className = "event-row write";
+        row.innerHTML =
+          `<span class="event-var">${escapeHtml(variable)}</span>` +
+          `<span class="event-op">:=</span>` +
+          `<span class="event-val">${escapeHtml(String(version))}</span>`;
+        card.appendChild(row);
+      }
+      for (const [variable, version] of Object.entries(tx.reads)) {
+        const row = document.createElement("div");
+        row.className = "event-row read";
+        row.innerHTML =
+          `<span class="event-var">${escapeHtml(variable)}</span>` +
+          `<span class="event-op">==</span>` +
+          `<span class="event-val">${
+            escapeHtml(version === null ? "?" : String(version))
+          }</span>`;
+        card.appendChild(row);
+      }
+
+      col.appendChild(card);
+    }
+
+    container.appendChild(col);
+  }
+}
+
+// -- Result rendering -------------------------------------------------------
+
+function renderResult(result: TraceResult, container: HTMLElement) {
+  container.innerHTML = "";
+
+  if (typeof result.error === "string" && !result.sessions) {
+    // Parse/input error
+    const badge = document.createElement("span");
+    badge.className = "result-badge error";
+    badge.textContent = "ERROR";
+    container.appendChild(badge);
+
+    const detail = document.createElement("span");
     detail.className = "result-detail";
     detail.textContent = String(result.error);
     container.appendChild(detail);
@@ -191,35 +430,115 @@ function renderResult(
   }
 
   if (result.ok) {
-    const heading = document.createElement("div");
-    heading.className = "result-pass";
-    heading.textContent = "PASS";
-    container.appendChild(heading);
+    const badge = document.createElement("span");
+    badge.className = "result-badge pass";
+    badge.textContent = "PASS";
+    container.appendChild(badge);
 
-    if (result.witness) {
-      const detail = document.createElement("div");
+    if (result.level) {
+      const detail = document.createElement("span");
       detail.className = "result-detail";
-      const witnessType = Object.keys(result.witness)[0] || "unknown";
-      detail.textContent = "Witness: " + witnessType + "\n" +
-        JSON.stringify(result.witness, null, 2);
+      const witnessType = result.witness
+        ? Object.keys(result.witness)[0] || ""
+        : "";
+      detail.textContent = result.level +
+        (witnessType ? " (" + witnessType + ")" : "");
       container.appendChild(detail);
     }
   } else {
-    const heading = document.createElement("div");
-    heading.className = "result-fail";
-    heading.textContent = "FAIL";
-    container.appendChild(heading);
+    const badge = document.createElement("span");
+    badge.className = "result-badge fail";
+    badge.textContent = "FAIL";
+    container.appendChild(badge);
 
-    if (result.error) {
-      const detail = document.createElement("div");
+    if (result.level) {
+      const detail = document.createElement("span");
       detail.className = "result-detail";
-      detail.textContent = JSON.stringify(result.error, null, 2);
+      detail.textContent = result.level;
       container.appendChild(detail);
     }
   }
 }
 
-function renderGraph(result: TraceResult): void {
+// -- Graph rendering --------------------------------------------------------
+
+function buildGraphStyle() {
+  const c = getThemeColors();
+  return [
+    {
+      selector: "node",
+      style: {
+        label: "data(label)",
+        "text-wrap": "wrap",
+        "text-valign": "center",
+        "text-halign": "center",
+        "font-size": "10px",
+        "font-family": "monospace",
+        color: c.text,
+        "background-color": c.nodeCommitted,
+        width: 60,
+        height: 60,
+        "border-width": 2,
+        "border-color": c.border,
+        "text-outline-color": c.bg,
+        "text-outline-width": 1,
+      },
+    },
+    {
+      selector: "node[?committed]",
+      style: { "background-color": c.nodeCommitted },
+    },
+    {
+      selector: "node[committed = false]",
+      style: { "background-color": c.nodeUncommitted },
+    },
+    {
+      selector: "edge",
+      style: {
+        width: 2,
+        "curve-style": "bezier",
+        "target-arrow-shape": "triangle",
+        "arrow-scale": 1.2,
+        label: "data(label)",
+        "font-size": "9px",
+        "font-family": "monospace",
+        color: c.muted,
+        "text-outline-color": c.bg,
+        "text-outline-width": 1,
+        "text-rotation": "autorotate",
+      },
+    },
+    {
+      selector: "edge[edgeType = 'wr']",
+      style: {
+        "line-color": c.edgeWr,
+        "target-arrow-color": c.edgeWr,
+      },
+    },
+    {
+      selector: "edge[edgeType = 'co']",
+      style: {
+        "line-color": c.edgeCo,
+        "target-arrow-color": c.edgeCo,
+      },
+    },
+    {
+      selector: "edge[edgeType = 'so']",
+      style: {
+        "line-color": c.edgeSo,
+        "target-arrow-color": c.edgeSo,
+        "line-style": "dashed",
+      },
+    },
+  ];
+}
+
+function reThemeCytoscape() {
+  if (!cy) return;
+  cy.style().fromJson(buildGraphStyle()).update();
+}
+
+function renderGraph(result: TraceResult) {
   const container = document.getElementById("graph-container")!;
   const legendEl = document.getElementById("legend")!;
 
@@ -238,10 +557,10 @@ function renderGraph(result: TraceResult): void {
   // deno-lint-ignore no-explicit-any
   const elements: any[] = [];
   const addedEdges = new Set<string>();
+
   for (const session of result.sessions) {
     for (const tx of session) {
       if (tx.id.session_id === 0) continue;
-
       elements.push({
         data: {
           id: txId(tx.id),
@@ -253,6 +572,7 @@ function renderGraph(result: TraceResult): void {
     }
   }
 
+  // Session order edges
   for (const session of result.sessions) {
     for (let i = 0; i < session.length - 1; i++) {
       const from = session[i];
@@ -274,6 +594,7 @@ function renderGraph(result: TraceResult): void {
     }
   }
 
+  // Write-read edges
   if (result.wr_edges) {
     for (const [from, to] of result.wr_edges) {
       if (from.session_id === 0 || to.session_id === 0) continue;
@@ -293,6 +614,7 @@ function renderGraph(result: TraceResult): void {
     }
   }
 
+  // Commit order / witness edges
   if (result.witness_edges) {
     for (const [from, to] of result.witness_edges) {
       if (from.session_id === 0 || to.session_id === 0) continue;
@@ -315,77 +637,7 @@ function renderGraph(result: TraceResult): void {
   cy = cytoscape({
     container: container,
     elements: elements,
-    style: [
-      {
-        selector: "node",
-        style: {
-          label: "data(label)",
-          "text-wrap": "wrap",
-          "text-valign": "center",
-          "text-halign": "center",
-          "font-size": "10px",
-          "font-family": "monospace",
-          color: "#e0e0e0",
-          "background-color": "#4cc9a0",
-          width: 60,
-          height: 60,
-          "border-width": 2,
-          "border-color": "#333",
-          "text-outline-color": "#0f0f1a",
-          "text-outline-width": 1,
-        },
-      },
-      {
-        selector: "node[?committed]",
-        style: {
-          "background-color": "#4cc9a0",
-        },
-      },
-      {
-        selector: "node[committed = false]",
-        style: {
-          "background-color": "#555",
-        },
-      },
-      {
-        selector: "edge",
-        style: {
-          width: 2,
-          "curve-style": "bezier",
-          "target-arrow-shape": "triangle",
-          "arrow-scale": 1.2,
-          label: "data(label)",
-          "font-size": "9px",
-          "font-family": "monospace",
-          color: "#888",
-          "text-outline-color": "#0f0f1a",
-          "text-outline-width": 1,
-          "text-rotation": "autorotate",
-        },
-      },
-      {
-        selector: "edge[edgeType = 'wr']",
-        style: {
-          "line-color": "#4361ee",
-          "target-arrow-color": "#4361ee",
-        },
-      },
-      {
-        selector: "edge[edgeType = 'co']",
-        style: {
-          "line-color": "#f7931e",
-          "target-arrow-color": "#f7931e",
-        },
-      },
-      {
-        selector: "edge[edgeType = 'so']",
-        style: {
-          "line-color": "#666",
-          "target-arrow-color": "#666",
-          "line-style": "dashed",
-        },
-      },
-    ],
+    style: buildGraphStyle(),
     layout: {
       name: "dagre",
       rankDir: "LR",
@@ -398,12 +650,14 @@ function renderGraph(result: TraceResult): void {
     boxSelectionEnabled: false,
   });
 
+  // Legend
+  const c = getThemeColors();
   const legendItems = [
-    { color: "#4cc9a0", text: "Committed node" },
-    { color: "#555", text: "Uncommitted node" },
-    { color: "#4361ee", text: "WR (write-read)" },
-    { color: "#f7931e", text: "CO (commit order)" },
-    { color: "#666", text: "SO (session order)" },
+    { color: c.nodeCommitted, text: "Committed" },
+    { color: c.nodeUncommitted, text: "Uncommitted" },
+    { color: c.edgeWr, text: "WR (write-read)" },
+    { color: c.edgeCo, text: "CO (commit order)" },
+    { color: c.edgeSo, text: "SO (session order)" },
   ];
 
   for (const item of legendItems) {
@@ -420,12 +674,15 @@ function renderGraph(result: TraceResult): void {
   }
 }
 
-// -- Setup -------------------------------------------------------------------
+// -- Setup ------------------------------------------------------------------
 
-function setup(): void {
-  const historyInput = document.getElementById(
-    "history-json",
+function setup() {
+  const input = document.getElementById(
+    "history-input",
   ) as HTMLTextAreaElement;
+  const overlay = document.getElementById(
+    "highlight-overlay",
+  ) as HTMLDivElement;
   const levelSelect = document.getElementById(
     "level-select",
   ) as HTMLSelectElement;
@@ -433,15 +690,46 @@ function setup(): void {
     "example-select",
   ) as HTMLSelectElement;
   const checkBtn = document.getElementById("check-btn") as HTMLButtonElement;
-  const resultOutput = document.getElementById(
-    "result-output",
-  ) as HTMLDivElement;
+  const resultBar = document.getElementById("result-bar") as HTMLDivElement;
+  const fmtText = document.getElementById("fmt-text") as HTMLButtonElement;
+  const fmtJson = document.getElementById("fmt-json") as HTMLButtonElement;
+  const themeToggle = document.getElementById(
+    "theme-toggle",
+  ) as HTMLButtonElement;
 
-  function loadExample(key: string): void {
-    const example = EXAMPLES[key];
-    if (!example) return;
-    historyInput.value = JSON.stringify(example.history, null, 2);
-    levelSelect.value = example.level;
+  // -- Theme
+  initTheme();
+  themeToggle.addEventListener("click", toggleTheme);
+
+  // -- Format toggle
+  function setFormat(fmt: "text" | "json") {
+    currentFormat = fmt;
+    fmtText.classList.toggle("active", fmt === "text");
+    fmtJson.classList.toggle("active", fmt === "json");
+    input.placeholder = fmt === "text"
+      ? "Enter history in compact text format..."
+      : "Enter history as JSON array...";
+    loadExample(exampleSelect.value);
+  }
+
+  fmtText.addEventListener("click", () => setFormat("text"));
+  fmtJson.addEventListener("click", () => setFormat("json"));
+
+  // -- Examples
+  function loadExample(key: string) {
+    if (currentFormat === "text") {
+      const ex = TEXT_EXAMPLES[key];
+      if (!ex) return;
+      input.value = ex.text;
+      levelSelect.value = ex.level;
+      highlightText(input.value, overlay);
+    } else {
+      const ex = JSON_EXAMPLES[key];
+      if (!ex) return;
+      input.value = JSON.stringify(ex.json, null, 2);
+      levelSelect.value = ex.level;
+      overlay.innerHTML = "";
+    }
   }
 
   loadExample(exampleSelect.value);
@@ -450,24 +738,43 @@ function setup(): void {
     loadExample(exampleSelect.value);
   });
 
+  // -- Syntax highlighting on input (text mode)
+  input.addEventListener("input", () => {
+    highlightText(input.value, overlay);
+  });
+
+  // Sync scroll between textarea and overlay
+  input.addEventListener("scroll", () => {
+    overlay.scrollTop = input.scrollTop;
+    overlay.scrollLeft = input.scrollLeft;
+  });
+
+  // -- Check button
   checkBtn.addEventListener("click", () => {
-    const history = historyInput.value;
+    const value = input.value;
     const level = levelSelect.value;
+
     try {
-      const raw = check_consistency_trace(history, level);
+      let raw: string;
+      if (currentFormat === "text") {
+        raw = check_consistency_trace_text(value, level);
+      } else {
+        raw = check_consistency_trace(value, level);
+      }
       const result: TraceResult = JSON.parse(raw);
-      renderResult(result, resultOutput);
+      renderResult(result, resultBar);
+      renderSessions(result);
       renderGraph(result);
     } catch (e) {
-      resultOutput.innerHTML = "";
-      const heading = document.createElement("div");
-      heading.className = "result-fail";
-      heading.textContent = "ERROR";
-      resultOutput.appendChild(heading);
-      const detail = document.createElement("div");
+      resultBar.innerHTML = "";
+      const badge = document.createElement("span");
+      badge.className = "result-badge error";
+      badge.textContent = "ERROR";
+      resultBar.appendChild(badge);
+      const detail = document.createElement("span");
       detail.className = "result-detail";
       detail.textContent = String(e);
-      resultOutput.appendChild(detail);
+      resultBar.appendChild(detail);
     }
   });
 }

--- a/web/style.css
+++ b/web/style.css
@@ -1,144 +1,509 @@
+/* -- Theme variables -------------------------------------------------------- */
 :root {
   --bg: #0f0f1a;
   --surface: #1a1a2e;
+  --surface-alt: #222240;
   --accent: #4361ee;
   --text: #e0e0e0;
+  --text-secondary: #aaa;
   --muted: #888;
   --border: #333;
   --success: #4cc9a0;
   --error: #f72585;
+  --highlight: #4361ee22;
+
+  /* graph colors */
+  --node-committed: #4cc9a0;
+  --node-uncommitted: #555;
+  --edge-wr: #4361ee;
+  --edge-co: #f7931e;
+  --edge-so: #666;
+
+  /* syntax highlighting */
+  --syn-keyword: #c792ea;
+  --syn-variable: #82aaff;
+  --syn-number: #f78c6c;
+  --syn-comment: #546e7a;
+  --syn-bracket: #89ddff;
+  --syn-operator: #ffcb6b;
+  --syn-separator: #f72585;
 }
+
+[data-theme="light"] {
+  --bg: #f5f5f8;
+  --surface: #ffffff;
+  --surface-alt: #eeeef2;
+  --accent: #3a50d9;
+  --text: #1a1a2e;
+  --text-secondary: #555;
+  --muted: #777;
+  --border: #d0d0d8;
+  --success: #2a9d6e;
+  --error: #d62369;
+  --highlight: #3a50d922;
+
+  --node-committed: #2a9d6e;
+  --node-uncommitted: #aaa;
+  --edge-wr: #3a50d9;
+  --edge-co: #e07c0a;
+  --edge-so: #999;
+
+  --syn-keyword: #7c3aed;
+  --syn-variable: #2563eb;
+  --syn-number: #d97706;
+  --syn-comment: #94a3b8;
+  --syn-bracket: #0891b2;
+  --syn-operator: #ca8a04;
+  --syn-separator: #d62369;
+}
+
+/* -- Reset & base --------------------------------------------------------- */
 * {
   box-sizing: border-box;
   margin: 0;
   padding: 0;
 }
+
 body {
   background: var(--bg);
   color: var(--text);
-  font-family: system-ui, sans-serif;
-  padding: 2rem;
+  font-family: system-ui, -apple-system, sans-serif;
+  transition: background 0.2s, color 0.2s;
 }
+
+/* -- Layout --------------------------------------------------------------- */
+.app {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  min-height: 100vh;
+}
+
 header {
-  margin-bottom: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 2rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+  transition: background 0.2s, border-color 0.2s;
 }
+
+header .title {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
 header h1 {
-  font-size: 2rem;
+  font-size: 1.5rem;
   color: var(--accent);
   font-family: monospace;
+  font-weight: 700;
 }
-header p {
+
+header .subtitle {
   color: var(--muted);
+  font-size: 0.85rem;
 }
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+/* -- Theme toggle --------------------------------------------------------- */
+.theme-toggle {
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.4rem 0.6rem;
+  cursor: pointer;
+  color: var(--text);
+  font-size: 1.1rem;
+  line-height: 1;
+  transition: background 0.2s, border-color 0.2s;
+}
+
+.theme-toggle:hover {
+  background: var(--highlight);
+}
+
+/* -- Main grid ------------------------------------------------------------ */
 main {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 2rem;
+  grid-template-columns: 340px 1fr;
+  grid-template-rows: 1fr;
+  overflow: hidden;
 }
-section {
+
+/* -- Sidebar (input) ------------------------------------------------------ */
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  border-right: 1px solid var(--border);
   background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 1.5rem;
+  overflow-y: auto;
+  transition: background 0.2s, border-color 0.2s;
 }
-section h2 {
-  font-size: 1rem;
+
+.sidebar-section {
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.sidebar-section:last-child {
+  border-bottom: none;
+}
+
+.sidebar-section h2 {
+  font-size: 0.7rem;
   text-transform: uppercase;
-  color: var(--muted);
   letter-spacing: 0.1em;
-  margin-bottom: 1rem;
+  color: var(--muted);
+  margin-bottom: 0.75rem;
 }
-#graph-section {
-  grid-column: 1 / -1;
+
+/* -- Format toggle -------------------------------------------------------- */
+.format-toggle {
+  display: flex;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+  margin-bottom: 0.75rem;
 }
+
+.format-toggle button {
+  flex: 1;
+  padding: 0.4rem 0.75rem;
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 0.8rem;
+  font-weight: 500;
+  transition: background 0.15s, color 0.15s;
+}
+
+.format-toggle button.active {
+  background: var(--accent);
+  color: #fff;
+}
+
+.format-toggle button:hover:not(.active) {
+  background: var(--highlight);
+  color: var(--text);
+}
+
+/* -- Textarea & editor ---------------------------------------------------- */
+.editor-wrap {
+  position: relative;
+}
+
 textarea {
   width: 100%;
-  font-family: monospace;
-  font-size: 0.85rem;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.82rem;
+  line-height: 1.5;
   background: var(--bg);
   color: var(--text);
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: 6px;
   padding: 0.75rem;
   resize: vertical;
+  min-height: 180px;
+  transition: background 0.2s, border-color 0.2s, color 0.2s;
 }
+
+textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+/* -- Syntax highlighted overlay ------------------------------------------- */
+.highlight-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  pointer-events: none;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.82rem;
+  line-height: 1.5;
+  padding: 0.75rem;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow: hidden;
+}
+
+.highlight-overlay .syn-comment {
+  color: var(--syn-comment);
+}
+.highlight-overlay .syn-bracket {
+  color: var(--syn-bracket);
+  font-weight: 600;
+}
+.highlight-overlay .syn-operator {
+  color: var(--syn-operator);
+}
+.highlight-overlay .syn-variable {
+  color: var(--syn-variable);
+}
+.highlight-overlay .syn-number {
+  color: var(--syn-number);
+}
+.highlight-overlay .syn-separator {
+  color: var(--syn-separator);
+  font-weight: 600;
+}
+.highlight-overlay .syn-bang {
+  color: var(--error);
+  font-weight: 700;
+}
+.highlight-overlay .syn-question {
+  color: var(--syn-keyword);
+}
+
 select {
   width: 100%;
-  padding: 0.5rem;
-  margin-top: 0.5rem;
+  padding: 0.5rem 0.75rem;
   background: var(--bg);
   color: var(--text);
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  transition: background 0.2s, border-color 0.2s, color 0.2s;
 }
+
+select:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
 #example-select {
-  margin-top: 0;
   margin-bottom: 0.5rem;
 }
-button {
-  margin-top: 1rem;
-  padding: 0.75rem 2rem;
+
+button.check-btn {
+  width: 100%;
+  padding: 0.65rem 1.5rem;
   background: var(--accent);
   color: #fff;
   border: none;
-  border-radius: 4px;
+  border-radius: 6px;
   cursor: pointer;
-  font-size: 1rem;
-  width: 100%;
+  font-size: 0.9rem;
+  font-weight: 600;
+  transition: opacity 0.15s;
 }
-button:hover {
-  opacity: 0.9;
+
+button.check-btn:hover {
+  opacity: 0.88;
 }
-pre {
-  font-family: monospace;
-  font-size: 0.8rem;
-  overflow: auto;
-  white-space: pre-wrap;
-  word-break: break-word;
-  color: var(--text);
+
+/* -- Content area --------------------------------------------------------- */
+.content {
+  display: grid;
+  grid-template-rows: auto auto 1fr;
+  overflow: hidden;
 }
-#result-output {
-  color: var(--muted);
+
+/* -- Result bar ----------------------------------------------------------- */
+.result-bar {
+  padding: 0.75rem 1.5rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+  transition: background 0.2s, border-color 0.2s;
+  min-height: 3rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
 }
-.result-pass {
-  color: var(--success);
-  font-size: 1.5rem;
-  font-weight: bold;
+
+.result-badge {
+  font-size: 0.85rem;
+  font-weight: 700;
+  padding: 0.2rem 0.75rem;
+  border-radius: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
-.result-fail {
-  color: var(--error);
-  font-size: 1.5rem;
-  font-weight: bold;
+
+.result-badge.pass {
+  background: var(--success);
+  color: #fff;
 }
+
+.result-badge.fail {
+  background: var(--error);
+  color: #fff;
+}
+
+.result-badge.error {
+  background: var(--muted);
+  color: #fff;
+}
+
 .result-detail {
   font-family: monospace;
-  font-size: 0.8rem;
-  margin-top: 0.5rem;
+  font-size: 0.78rem;
+  color: var(--text-secondary);
   white-space: pre-wrap;
   word-break: break-word;
-  color: var(--text);
+  max-height: 6rem;
+  overflow-y: auto;
 }
-#graph-container {
-  min-height: 500px;
+
+.result-placeholder {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+/* -- Sessions display ----------------------------------------------------- */
+.sessions-panel {
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid var(--border);
+  overflow-x: auto;
   background: var(--bg);
-  border-radius: 4px;
+  transition: background 0.2s, border-color 0.2s;
 }
+
+.sessions-container {
+  display: flex;
+  gap: 1.25rem;
+  min-height: 80px;
+}
+
+.session-column {
+  flex: 0 0 auto;
+  min-width: 160px;
+  max-width: 260px;
+}
+
+.session-header {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+}
+
+.txn-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.5rem 0.65rem;
+  margin-bottom: 0.5rem;
+  transition: background 0.2s, border-color 0.2s;
+}
+
+.txn-card.uncommitted {
+  border-style: dashed;
+  opacity: 0.7;
+}
+
+.txn-card-header {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--muted);
+  margin-bottom: 0.3rem;
+  font-family: monospace;
+}
+
+.event-row {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: monospace;
+  font-size: 0.78rem;
+  padding: 0.15rem 0;
+  padding-left: 0.5rem;
+  border-left: 3px solid transparent;
+}
+
+.event-row.write {
+  border-left-color: var(--success);
+}
+
+.event-row.read {
+  border-left-color: var(--edge-wr);
+}
+
+.event-var {
+  color: var(--syn-variable);
+}
+
+.event-op {
+  color: var(--muted);
+}
+
+.event-val {
+  color: var(--syn-number);
+}
+
+/* -- Graph panel ---------------------------------------------------------- */
+.graph-panel {
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+#graph-container {
+  flex: 1;
+  min-height: 300px;
+  background: var(--bg);
+  transition: background 0.2s;
+}
+
 #legend {
   display: flex;
   gap: 1rem;
-  font-size: 0.8rem;
+  font-size: 0.75rem;
   color: var(--muted);
-  margin-top: 0.5rem;
+  padding: 0.5rem 1.5rem;
   flex-wrap: wrap;
+  border-top: 1px solid var(--border);
+  background: var(--surface);
+  transition: background 0.2s, border-color 0.2s;
 }
+
 .legend-item {
   display: flex;
   align-items: center;
   gap: 0.25rem;
 }
+
 .legend-dot {
-  width: 12px;
-  height: 12px;
+  width: 10px;
+  height: 10px;
   border-radius: 50%;
   display: inline-block;
+}
+
+/* -- Responsive ----------------------------------------------------------- */
+@media (max-width: 800px) {
+  main {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr;
+  }
+
+  .sidebar {
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+    max-height: 50vh;
+  }
+
+  .sessions-container {
+    flex-direction: column;
+  }
+
+  .session-column {
+    max-width: none;
+  }
 }


### PR DESCRIPTION
## Summary

- **Compact text DSL**: Human-readable format for transactional histories with winnow parser, logos lexer, Display impls, and round-trip guarantee. Grammar uses `[x:=1 y==2]` for transactions, `---` for session separators, `//` for comments, `!` for uncommitted, `?` for uninitialized reads.
- **CLI integration**: `dbcop fmt` subcommand for `.hist` file formatting (with `--check` mode), `dbcop verify` now accepts `.hist` and `.txt` files alongside `.json`.
- **WASM exports**: `parse_history_text()`, `check_consistency_trace_text()`, `tokenize_history()` for web UI integration with string variable names preserved.
- **Web UI redesign**: Dark/light theme toggle with CSS custom properties, sidebar layout with format toggle (Text/JSON), parallel session columns with transaction cards, syntax highlighting for text DSL, cytoscape re-theming on theme switch, responsive mobile layout.
- **Compact serde** (feature-gated): `compact-serde` feature for tuple serialization `["w", var, ver]` / `["r", var, ver]`, with backward-compatible Deserialize that accepts both tagged enum and compact formats.

## Test plan

- [x] `cargo test -p dbcop_core --features "serde,parser"` — all tests pass
- [x] `cargo test -p dbcop_core --features compact-serde` — compact serde tests pass
- [x] `cargo test -p dbcop_core` (no features) — existing tests unaffected
- [x] `cargo build -p dbcop_wasm --target wasm32-unknown-unknown --release` — WASM builds
- [x] `cargo build -p dbcop_cli` — CLI builds
- [x] `deno task deno:ci` — fmt, lint, check all pass
- [x] `deno run -A web/build.ts` — dist build succeeds
- [x] Zero warnings across all feature combinations
- [ ] Manual: open web app, toggle theme, enter text DSL, verify sessions render as parallel columns
- [ ] Manual: verify JSON examples still work with format toggle
- [ ] Manual: verify cytoscape graph colors update on theme toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)