### PR TITLE
docs: document compact text DSL (.hist format) in history-format.md

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -202,4 +202,4 @@ avoidance rule.
 
 - [History Format](history-format.md) -- JSON schema for input files
 - [Consistency Models](consistency-models.md) -- what each level means
-- [Web and WASM](web-and-wasm.md) -- browser-based alternative
+- [WASM API](wasm-api.md) -- WASM bindings API reference


### PR DESCRIPTION
## Summary

- `docs/history-format.md` was missing any mention of the `.hist` / `.txt` compact text DSL that `dbcop verify` and `dbcop fmt` both accept
- Adds a new **"Text Format (.hist)"** section with grammar, syntax reference table, key differences from JSON, two worked examples, and `dbcop fmt` usage
- Fixes a stale link in `docs/cli-reference.md`: `web-and-wasm.md` → `wasm-api.md` (file was renamed in the previous PR)

## Changes

- `docs/history-format.md`: new `## Text Format (.hist)` section inserted before `## From Raw to Atomic`
- `docs/cli-reference.md`: stale See Also link corrected