### PR TITLE
fix(core): correct consistency checker ordering constraints

### DIFF
--- a/crates/core/tests/consistency.rs
+++ b/crates/core/tests/consistency.rs
@@ -125,18 +125,25 @@ fn atomic_read_pass() {
 
 #[test]
 fn atomic_read_violation() {
-    // S1 has two transactions: write(x,1), write(x,2).
-    // S2 has two transactions: read(x,2), read(x,1).
-    // S2's second txn reads an older version after seeing a newer one -- violates atomic visibility.
+    // Fractured visibility history:
+    // s1: write x=1,y=1
+    // s2: read y=1, write x=2,z=1
+    // s3: read x=1, read z=1
+    // AtomicRead should fail due a visibility cycle after ww saturation.
     let h: Vec<Session<&str, u64>> = vec![
-        vec![
-            Transaction::committed(vec![Event::write("x", 1)]),
-            Transaction::committed(vec![Event::write("x", 2)]),
-        ],
-        vec![
-            Transaction::committed(vec![Event::read("x", 2)]),
-            Transaction::committed(vec![Event::read("x", 1)]),
-        ],
+        vec![Transaction::committed(vec![
+            Event::write("x", 1),
+            Event::write("y", 1),
+        ])],
+        vec![Transaction::committed(vec![
+            Event::read("y", 1),
+            Event::write("x", 2),
+            Event::write("z", 1),
+        ])],
+        vec![Transaction::committed(vec![
+            Event::read("x", 1),
+            Event::read("z", 1),
+        ])],
     ];
 
     let result = check_atomic_read(&h);

--- a/crates/core/tests/consistency_hierarchy.rs
+++ b/crates/core/tests/consistency_hierarchy.rs
@@ -258,7 +258,6 @@ fn boundary_snapshot_isolation_to_serializable() {
 ///   S2: r(y,2) from S1, r(x,2) from S1.
 ///   S3: r(z,2) from S2, r(x,2) from S1, r(y,3) from S2.
 /// No cycles, no anti-dependencies -- passes Serializable.
-#[ignore = "history design needs rework: current history causes a causal cycle"]
 #[test]
 fn passes_serializable() {
     let h: Vec<Session<&str, u64>> = vec![


### PR DESCRIPTION
## Summary
- fix writer filtering in core causal saturation (`causal_ww`/`causal_rw`) so reader-only vertices are not treated as writers
- fix local raw-history validation to preserve read-your-write semantics within a transaction
- re-enable `passes_serializable` in `consistency_hierarchy`
- align SAT encodings (SER/PC/SI) with core semantics: writer-only constraints and root-reader ordering constraints
- update affected tests and `AGENTS.md`

## Validation
- cargo +nightly fmt --check --all
- cargo build --verbose --all-features
- cargo clippy --workspace --all-features -- -D warnings
- cargo test --verbose --all-features
- cargo install --path crates/cli
- dbcop generate/verify e2e
- taplo format --check
- typos
- deno task wasmbuild
- deno task deno:fmt
- deno task deno:lint
- deno task deno:check
- deno test -A crates/wasm/tests/
- cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info
- deno test -A --coverage=coverage/deno crates/wasm/tests/
- deno coverage coverage/deno --lcov --output=coverage/deno.lcov
- act --list
- zizmor .github/workflows/
