### PR TITLE
fix(core): preserve singleton sessions in decomposed NPC witnesses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -374,6 +374,10 @@ notepads, and agent memory.
   against core NPC solvers (`DBCOP_DIFF_FUZZ_SAMPLES`, default 256).
 - `crates/core/benches/consistency.rs` -- 18 Criterion benchmarks (6 consistency
   levels x 3 history sizes).
+- `crates/sat/benches/npc_vs_sat.rs` -- Criterion comparison benchmark for
+  Prefix/SnapshotIsolation/Serializable using randomly sampled valid histories;
+  reports prebench SAT/Core average latency ratio and benchmarks both solver
+  paths.
 - Always add tests when adding new functionality.
 
 ## AGENTS.md Update Protocol

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,9 +331,11 @@ notepads, and agent memory.
 - Communication graph decomposition (`consistency/mod.rs`, `dbcop_sat/lib.rs`):
   decomposes history by connected components of the communication graph (Theorem
   5.2 from Biswas & Enea 2019). Checks each component independently, then remaps
-  and merges witnesses. Reduces DFS/SAT search space from O(n!) to O(sum of
-  k_i!) where k_i are component sizes. Applied to NP-complete levels only:
-  Prefix, SnapshotIsolation, Serializable.
+  and merges witnesses. Decomposition must include singleton components as well,
+  otherwise merged Prefix/SI/Serializable witnesses can drop isolated sessions.
+  Reduces DFS/SAT search space from O(n!) to O(sum of k_i!) where k_i are
+  component sizes. Applied to NP-complete levels only: Prefix,
+  SnapshotIsolation, Serializable.
 
 - Incremental transitive closure (`digraph.rs`): `incremental_closure()` extends
   an existing closed graph with new edges using BFS ancestor/descendant
@@ -357,9 +359,11 @@ notepads, and agent memory.
   `test_inconsistent_local_read_before_write`.
 - `crates/core/tests/paper_polynomial.rs` -- 13 tests verifying polynomial-time
   checker correctness against known histories.
-- `crates/core/tests/decomposition_check.rs` -- 3 tests verifying communication
-  graph decomposition in NP-complete checkers (independent clusters, single
-  cluster fallback, write-skew detection across components).
+- `crates/core/tests/decomposition_check.rs` -- 6 tests verifying communication
+  graph decomposition in NP-complete checkers, including singleton-component
+  witness preservation for Prefix/SI/Serializable.
+- `crates/sat/tests/cross_check.rs` includes SAT witness regression tests for
+  singleton-component preservation in Prefix and Snapshot Isolation.
 - `crates/core/benches/consistency.rs` -- 18 Criterion benchmarks (6 consistency
   levels x 3 history sizes).
 - Always add tests when adding new functionality.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -336,6 +336,11 @@ notepads, and agent memory.
   Reduces DFS/SAT search space from O(n!) to O(sum of k_i!) where k_i are
   component sizes. Applied to NP-complete levels only: Prefix,
   SnapshotIsolation, Serializable.
+- Singleton NPC fast-path (`consistency/mod.rs`, `dbcop_sat/lib.rs`): when the
+  projected history has exactly one session, skip DFS/SAT linearization search
+  and synthesize the trivial witness from session order after causal check. Also
+  applied per component during decomposition to avoid recursive re-checking and
+  SAT solving for singleton components.
 
 - Incremental transitive closure (`digraph.rs`): `incremental_closure()` extends
   an existing closed graph with new edges using BFS ancestor/descendant
@@ -359,11 +364,13 @@ notepads, and agent memory.
   `test_inconsistent_local_read_before_write`.
 - `crates/core/tests/paper_polynomial.rs` -- 13 tests verifying polynomial-time
   checker correctness against known histories.
-- `crates/core/tests/decomposition_check.rs` -- 6 tests verifying communication
+- `crates/core/tests/decomposition_check.rs` -- 9 tests verifying communication
   graph decomposition in NP-complete checkers, including singleton-component
-  witness preservation for Prefix/SI/Serializable.
+  witness preservation and single-session trivial witnesses for
+  Prefix/SI/Serializable.
 - `crates/sat/tests/cross_check.rs` includes SAT witness regression tests for
-  singleton-component preservation in Prefix and Snapshot Isolation.
+  singleton-component preservation and single-session fast-path coverage in
+  Prefix/SnapshotIsolation/Serializable.
 - `crates/core/benches/consistency.rs` -- 18 Criterion benchmarks (6 consistency
   levels x 3 history sizes).
 - Always add tests when adding new functionality.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -370,7 +370,8 @@ notepads, and agent memory.
   Prefix/SI/Serializable.
 - `crates/sat/tests/cross_check.rs` includes SAT witness regression tests for
   singleton-component preservation and single-session fast-path coverage in
-  Prefix/SnapshotIsolation/Serializable.
+  Prefix/SnapshotIsolation/Serializable, plus a bounded differential fuzz test
+  against core NPC solvers (`DBCOP_DIFF_FUZZ_SAMPLES`, default 256).
 - `crates/core/benches/consistency.rs` -- 18 Criterion benchmarks (6 consistency
   levels x 3 history sizes).
 - Always add tests when adding new functionality.

--- a/crates/core/benches/consistency.rs
+++ b/crates/core/benches/consistency.rs
@@ -1,11 +1,13 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, Criterion};
 use dbcop_core::consistency::Consistency;
 use dbcop_core::history::raw::types::{Event, Session, Transaction};
 
 /// Build a history with given dimensions.
 /// sessions: number of sessions
-/// txns_per_session: transactions per session
-/// events_per_txn: events per transaction
+/// `txns_per_session`: transactions per session
+/// `events_per_txn`: events per transaction
 fn build_history(
     sessions: usize,
     txns_per_session: usize,
@@ -48,6 +50,7 @@ fn build_history(
     result
 }
 
+#[allow(clippy::too_many_lines)]
 fn bench_consistency(c: &mut Criterion) {
     // Small: 2 sessions, 3 txns each, 3 events per txn
     let history_small = build_history(2, 3, 3);
@@ -63,169 +66,169 @@ fn bench_consistency(c: &mut Criterion) {
     // CommittedRead benchmarks
     group.bench_function("committed_read_small", |b| {
         b.iter(|| {
-            dbcop_core::consistency::check(
+            let _ = dbcop_core::consistency::check(
                 black_box(&history_small),
                 black_box(Consistency::CommittedRead),
-            )
-        })
+            );
+        });
     });
 
     group.bench_function("committed_read_medium", |b| {
         b.iter(|| {
-            dbcop_core::consistency::check(
+            let _ = dbcop_core::consistency::check(
                 black_box(&history_medium),
                 black_box(Consistency::CommittedRead),
-            )
-        })
+            );
+        });
     });
 
     group.bench_function("committed_read_large", |b| {
         b.iter(|| {
-            dbcop_core::consistency::check(
+            let _ = dbcop_core::consistency::check(
                 black_box(&history_large),
                 black_box(Consistency::CommittedRead),
-            )
-        })
+            );
+        });
     });
 
     // AtomicRead benchmarks
     group.bench_function("atomic_read_small", |b| {
         b.iter(|| {
-            dbcop_core::consistency::check(
+            let _ = dbcop_core::consistency::check(
                 black_box(&history_small),
                 black_box(Consistency::AtomicRead),
-            )
-        })
+            );
+        });
     });
 
     group.bench_function("atomic_read_medium", |b| {
         b.iter(|| {
-            dbcop_core::consistency::check(
+            let _ = dbcop_core::consistency::check(
                 black_box(&history_medium),
                 black_box(Consistency::AtomicRead),
-            )
-        })
+            );
+        });
     });
 
     group.bench_function("atomic_read_large", |b| {
         b.iter(|| {
-            dbcop_core::consistency::check(
+            let _ = dbcop_core::consistency::check(
                 black_box(&history_large),
                 black_box(Consistency::AtomicRead),
-            )
-        })
+            );
+        });
     });
 
     // Causal benchmarks
     group.bench_function("causal_small", |b| {
         b.iter(|| {
-            dbcop_core::consistency::check(
+            let _ = dbcop_core::consistency::check(
                 black_box(&history_small),
                 black_box(Consistency::Causal),
-            )
-        })
+            );
+        });
     });
 
     group.bench_function("causal_medium", |b| {
         b.iter(|| {
-            dbcop_core::consistency::check(
+            let _ = dbcop_core::consistency::check(
                 black_box(&history_medium),
                 black_box(Consistency::Causal),
-            )
-        })
+            );
+        });
     });
 
     group.bench_function("causal_large", |b| {
         b.iter(|| {
-            dbcop_core::consistency::check(
+            let _ = dbcop_core::consistency::check(
                 black_box(&history_large),
                 black_box(Consistency::Causal),
-            )
-        })
+            );
+        });
     });
 
     // Prefix benchmarks
     group.bench_function("prefix_small", |b| {
         b.iter(|| {
-            dbcop_core::consistency::check(
+            let _ = dbcop_core::consistency::check(
                 black_box(&history_small),
                 black_box(Consistency::Prefix),
-            )
-        })
+            );
+        });
     });
 
     group.bench_function("prefix_medium", |b| {
         b.iter(|| {
-            dbcop_core::consistency::check(
+            let _ = dbcop_core::consistency::check(
                 black_box(&history_medium),
                 black_box(Consistency::Prefix),
-            )
-        })
+            );
+        });
     });
 
     group.bench_function("prefix_large", |b| {
         b.iter(|| {
-            dbcop_core::consistency::check(
+            let _ = dbcop_core::consistency::check(
                 black_box(&history_large),
                 black_box(Consistency::Prefix),
-            )
-        })
+            );
+        });
     });
 
     // SnapshotIsolation benchmarks
     group.bench_function("snapshot_isolation_small", |b| {
         b.iter(|| {
-            dbcop_core::consistency::check(
+            let _ = dbcop_core::consistency::check(
                 black_box(&history_small),
                 black_box(Consistency::SnapshotIsolation),
-            )
-        })
+            );
+        });
     });
 
     group.bench_function("snapshot_isolation_medium", |b| {
         b.iter(|| {
-            dbcop_core::consistency::check(
+            let _ = dbcop_core::consistency::check(
                 black_box(&history_medium),
                 black_box(Consistency::SnapshotIsolation),
-            )
-        })
+            );
+        });
     });
 
     group.bench_function("snapshot_isolation_large", |b| {
         b.iter(|| {
-            dbcop_core::consistency::check(
+            let _ = dbcop_core::consistency::check(
                 black_box(&history_large),
                 black_box(Consistency::SnapshotIsolation),
-            )
-        })
+            );
+        });
     });
 
     // Serializable benchmarks
     group.bench_function("serializable_small", |b| {
         b.iter(|| {
-            dbcop_core::consistency::check(
+            let _ = dbcop_core::consistency::check(
                 black_box(&history_small),
                 black_box(Consistency::Serializable),
-            )
-        })
+            );
+        });
     });
 
     group.bench_function("serializable_medium", |b| {
         b.iter(|| {
-            dbcop_core::consistency::check(
+            let _ = dbcop_core::consistency::check(
                 black_box(&history_medium),
                 black_box(Consistency::Serializable),
-            )
-        })
+            );
+        });
     });
 
     group.bench_function("serializable_large", |b| {
         b.iter(|| {
-            dbcop_core::consistency::check(
+            let _ = dbcop_core::consistency::check(
                 black_box(&history_large),
                 black_box(Consistency::Serializable),
-            )
-        })
+            );
+        });
     });
 
     group.finish();

--- a/crates/core/src/consistency/decomposition.rs
+++ b/crates/core/src/consistency/decomposition.rs
@@ -263,10 +263,7 @@ mod tests {
             "Session 1 should exist"
         );
         assert!(
-            comm_graph
-                .adj_map
-                .get(&1)
-                .is_some_and(|neighbors| neighbors.is_empty()),
+            comm_graph.adj_map.get(&1).is_some_and(HashSet::is_empty),
             "Session 1 should have no neighbors"
         );
     }
@@ -306,9 +303,7 @@ mod tests {
                             .adj_map
                             .get(&i)
                             .is_some_and(|neighbors| neighbors.contains(&j)),
-                        "Sessions {} and {} should be connected",
-                        i,
-                        j
+                        "Sessions {i} and {j} should be connected",
                     );
                 }
             }

--- a/crates/core/src/consistency/linearization/prefix.rs
+++ b/crates/core/src/consistency/linearization/prefix.rs
@@ -213,8 +213,11 @@ mod tests {
         // Should contain both read and write phases for each transaction
         assert!(!lin.is_empty());
         // Filter to write-phase vertices only
-        let write_phases: Vec<_> = lin.iter().filter(|(_, is_write)| *is_write).collect();
-        assert_eq!(write_phases.len(), 2, "expected 2 write-phase entries");
+        assert_eq!(
+            lin.iter().filter(|(_, is_write)| *is_write).count(),
+            2,
+            "expected 2 write-phase entries",
+        );
     }
 
     #[test]
@@ -262,8 +265,11 @@ mod tests {
         );
         let lin = result.unwrap();
         // Write-phase vertices for all 3 transactions should be present
-        let write_phases: Vec<_> = lin.iter().filter(|(_, is_write)| *is_write).collect();
-        assert_eq!(write_phases.len(), 3, "expected 3 write-phase entries");
+        assert_eq!(
+            lin.iter().filter(|(_, is_write)| *is_write).count(),
+            3,
+            "expected 3 write-phase entries",
+        );
     }
 
     #[test]
@@ -294,8 +300,11 @@ mod tests {
             "multi-variable chain should be prefix-consistent"
         );
         let lin = result.unwrap();
-        let write_phases: Vec<_> = lin.iter().filter(|(_, is_write)| *is_write).collect();
-        assert_eq!(write_phases.len(), 3, "expected 3 write-phase entries");
+        assert_eq!(
+            lin.iter().filter(|(_, is_write)| *is_write).count(),
+            3,
+            "expected 3 write-phase entries",
+        );
     }
 
     #[test]

--- a/crates/core/src/consistency/mod.rs
+++ b/crates/core/src/consistency/mod.rs
@@ -165,13 +165,11 @@ fn singleton_session_witness<Variable, Version>(
     session: &Session<Variable, Version>,
     level: Consistency,
 ) -> Witness {
-    let commit_order: Vec<TransactionId> = session
-        .iter()
-        .enumerate()
+    let commit_order: Vec<TransactionId> = (0..)
+        .zip(session.iter())
         .map(|(session_height, _)| TransactionId {
             session_id: 1,
-            #[allow(clippy::cast_possible_truncation)]
-            session_height: session_height as u64,
+            session_height,
         })
         .collect();
 

--- a/crates/core/src/consistency/mod.rs
+++ b/crates/core/src/consistency/mod.rs
@@ -456,9 +456,9 @@ mod tests {
             panic!("expected SplitCommitOrder");
         };
         assert_eq!(order[0].0.session_id, 7);
-        assert_eq!(order[0].1, false);
+        assert!(!order[0].1);
         assert_eq!(order[1].0.session_id, 7);
-        assert_eq!(order[1].1, true);
+        assert!(order[1].1);
     }
 
     #[test]

--- a/crates/core/src/consistency/mod.rs
+++ b/crates/core/src/consistency/mod.rs
@@ -175,12 +175,9 @@ where
     let comm_graph = decomposition::communication_graph(&po);
     let all_components = decomposition::connected_components(&comm_graph);
 
-    // Only non-trivial components (>= 2 sessions) require a consistency check.
-    // Singleton sessions are trivially consistent after the causal check.
-    let components_to_check: Vec<BTreeSet<u64>> = all_components
-        .into_iter()
-        .filter(|c| c.len() >= 2)
-        .collect();
+    // Keep every component (including singletons) so the merged witness
+    // always covers all sessions in the original history.
+    let components_to_check: Vec<BTreeSet<u64>> = all_components;
 
     tracing::debug!(
         components = components_to_check.len(),
@@ -189,7 +186,7 @@ where
         "communication graph decomposition"
     );
 
-    // Single (or no) non-trivial component: run DFS directly on the pre-built PO.
+    // Single (or no) component: run DFS directly on the pre-built PO.
     if components_to_check.len() <= 1 {
         return match level {
             Consistency::Prefix => {

--- a/crates/core/src/consistency/mod.rs
+++ b/crates/core/src/consistency/mod.rs
@@ -165,11 +165,13 @@ fn singleton_session_witness<Variable, Version>(
     session: &Session<Variable, Version>,
     level: Consistency,
 ) -> Witness {
-    let commit_order: Vec<TransactionId> = (0..)
-        .zip(session.iter())
+    let commit_order: Vec<TransactionId> = session
+        .iter()
+        .enumerate()
         .map(|(session_height, _)| TransactionId {
             session_id: 1,
-            session_height,
+            #[allow(clippy::cast_possible_truncation)]
+            session_height: session_height as u64,
         })
         .collect();
 

--- a/crates/core/tests/common/mod.rs
+++ b/crates/core/tests/common/mod.rs
@@ -20,7 +20,7 @@
 /// - `w(var, val)` → `Event::write("var", val)`
 /// - `r(var, val)` → `Event::read("var", val)`
 /// - `r(var)`      → `Event::read_empty("var")`
-
+///
 /// Build a single Event.
 #[macro_export]
 macro_rules! ev {

--- a/crates/core/tests/consistency.rs
+++ b/crates/core/tests/consistency.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::doc_markdown)]
+
 use dbcop_core::consistency::atomic_read::check_atomic_read;
 use dbcop_core::consistency::causal::check_causal_read;
 use dbcop_core::consistency::committed_read::check_committed_read;

--- a/crates/core/tests/consistency_hierarchy.rs
+++ b/crates/core/tests/consistency_hierarchy.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::doc_markdown, clippy::missing_const_for_fn)]
+
 //! Tests enforcing the strict consistency hierarchy:
 //!   CommittedRead < AtomicRead < Causal < Prefix < SnapshotIsolation < Serializable
 //!

--- a/crates/core/tests/decomposition_check.rs
+++ b/crates/core/tests/decomposition_check.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::missing_const_for_fn)]
+
 //! Tests for communication graph decomposition in consistency checkers.
 
 use dbcop_core::consistency::Witness;

--- a/crates/core/tests/paper_polynomial.rs
+++ b/crates/core/tests/paper_polynomial.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::doc_markdown)]
+
 /// Tests for polynomial-time consistency checkers: RC, RR, RA.
 /// Uses the `history!` DSL macro defined in tests/common/mod.rs.
 mod common;

--- a/crates/core/tests/version_zero.rs
+++ b/crates/core/tests/version_zero.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::doc_markdown)]
+
 /// Integration tests for version-0 reads mapping to the initial state (Bug 3 fix).
 ///
 /// `x==0` (version Some(0) where 0 == Default::default()) is treated as reading

--- a/crates/sat/Cargo.toml
+++ b/crates/sat/Cargo.toml
@@ -15,5 +15,8 @@ dbcop_core     = { workspace = true }
 rustsat        = "0.7"
 rustsat-batsat = "0.7"
 
+[dev-dependencies]
+dbcop_testgen = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/sat/Cargo.toml
+++ b/crates/sat/Cargo.toml
@@ -16,7 +16,12 @@ rustsat        = "0.7"
 rustsat-batsat = "0.7"
 
 [dev-dependencies]
+criterion    = { version = "0.8", features = [ "html_reports" ] }
 dbcop_testgen = { workspace = true }
 
 [lints]
 workspace = true
+
+[[bench]]
+name    = "npc_vs_sat"
+harness = false

--- a/crates/sat/Cargo.toml
+++ b/crates/sat/Cargo.toml
@@ -16,7 +16,7 @@ rustsat        = "0.7"
 rustsat-batsat = "0.7"
 
 [dev-dependencies]
-criterion    = { version = "0.8", features = [ "html_reports" ] }
+criterion     = { version = "0.8", features = [ "html_reports" ] }
 dbcop_testgen = { workspace = true }
 
 [lints]

--- a/crates/sat/benches/npc_vs_sat.rs
+++ b/crates/sat/benches/npc_vs_sat.rs
@@ -1,0 +1,162 @@
+use std::cell::Cell;
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use dbcop_core::history::raw::types::Session;
+use dbcop_core::{check, Consistency};
+use dbcop_sat::{check_prefix, check_serializable, check_snapshot_isolation};
+use dbcop_testgen::generator::generate_single_history;
+
+type History = Vec<Session<u64, u64>>;
+
+#[derive(Clone, Copy)]
+enum NpcLevel {
+    Prefix,
+    SnapshotIsolation,
+    Serializable,
+}
+
+impl NpcLevel {
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Prefix => "prefix",
+            Self::SnapshotIsolation => "snapshot_isolation",
+            Self::Serializable => "serializable",
+        }
+    }
+
+    fn run_core(self, history: &History) -> bool {
+        let level = match self {
+            Self::Prefix => Consistency::Prefix,
+            Self::SnapshotIsolation => Consistency::SnapshotIsolation,
+            Self::Serializable => Consistency::Serializable,
+        };
+        check(history, level).is_ok()
+    }
+
+    fn run_sat(self, history: &History) -> bool {
+        match self {
+            Self::Prefix => check_prefix(history).is_ok(),
+            Self::SnapshotIsolation => check_snapshot_isolation(history).is_ok(),
+            Self::Serializable => check_serializable(history).is_ok(),
+        }
+    }
+}
+
+fn sample_random_histories(level: NpcLevel, target_count: usize) -> Vec<History> {
+    let mut histories = Vec::with_capacity(target_count);
+    let mut attempts = 0usize;
+    let max_attempts = target_count * 200;
+
+    while histories.len() < target_count && attempts < max_attempts {
+        attempts += 1;
+
+        #[allow(clippy::cast_possible_truncation)]
+        let n_node = 3 + (attempts % 5) as u64; // 3..=7 sessions
+        #[allow(clippy::cast_possible_truncation)]
+        let n_variable = 3 + (attempts % 6) as u64; // 3..=8 variables
+        #[allow(clippy::cast_possible_truncation)]
+        let n_transaction = 2 + (attempts % 3) as u64; // 2..=4 txns/session
+        #[allow(clippy::cast_possible_truncation)]
+        let n_event = 2 + (attempts % 3) as u64; // 2..=4 events/txn
+
+        let history = generate_single_history(n_node, n_variable, n_transaction, n_event);
+
+        let core_ok = level.run_core(&history);
+        let sat_ok = level.run_sat(&history);
+        assert_eq!(
+            core_ok,
+            sat_ok,
+            "SAT/Core disagreement while sampling {} benchmark input",
+            level.name(),
+        );
+
+        if core_ok {
+            histories.push(history);
+        }
+    }
+
+    assert_eq!(
+        histories.len(),
+        target_count,
+        "could not sample enough {} histories for benchmark in {max_attempts} attempts",
+        level.name(),
+    );
+
+    histories
+}
+
+fn print_prebench_stats(level: NpcLevel, histories: &[History]) {
+    let rounds = 8usize;
+    let mut core_total = Duration::ZERO;
+    let mut sat_total = Duration::ZERO;
+
+    for _ in 0..rounds {
+        let core_start = Instant::now();
+        for history in histories {
+            black_box(level.run_core(black_box(history)));
+        }
+        core_total += core_start.elapsed();
+
+        let sat_start = Instant::now();
+        for history in histories {
+            black_box(level.run_sat(black_box(history)));
+        }
+        sat_total += sat_start.elapsed();
+    }
+
+    let samples = u32::try_from(rounds * histories.len()).expect("sample count fits u32");
+    let core_avg = core_total / samples;
+    let sat_avg = sat_total / samples;
+    let ratio = sat_avg.as_secs_f64() / core_avg.as_secs_f64();
+
+    eprintln!(
+        "[npc_vs_sat:{}] prebench avg/core={}ns avg/sat={}ns sat/core={ratio:.3}",
+        level.name(),
+        core_avg.as_nanos(),
+        sat_avg.as_nanos(),
+    );
+}
+
+fn bench_level(c: &mut Criterion, level: NpcLevel) {
+    let histories = sample_random_histories(level, 12);
+    print_prebench_stats(level, &histories);
+
+    let mut group = c.benchmark_group(format!("npc_vs_sat_{}", level.name()));
+    group.sample_size(80);
+    group.measurement_time(Duration::from_secs(8));
+
+    let core_idx = Cell::new(0usize);
+    group.bench_function("core_npc_search", |b| {
+        b.iter(|| {
+            let i = core_idx.get();
+            core_idx.set((i + 1) % histories.len());
+            black_box(level.run_core(black_box(&histories[i])));
+        });
+    });
+
+    let sat_idx = Cell::new(0usize);
+    group.bench_function("sat_solver", |b| {
+        b.iter(|| {
+            let i = sat_idx.get();
+            sat_idx.set((i + 1) % histories.len());
+            black_box(level.run_sat(black_box(&histories[i])));
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_npc_vs_sat(c: &mut Criterion) {
+    for level in [
+        NpcLevel::Prefix,
+        NpcLevel::SnapshotIsolation,
+        NpcLevel::Serializable,
+    ] {
+        bench_level(c, level);
+    }
+}
+
+criterion_group!(benches, bench_npc_vs_sat);
+criterion_main!(benches);

--- a/crates/sat/src/lib.rs
+++ b/crates/sat/src/lib.rs
@@ -167,10 +167,10 @@ fn visibility_edges<Variable: Eq + Hash + Clone>(
 
 /// Decompose sessions by connected components of the communication graph.
 ///
-/// Returns `Some(components)` when 2+ non-trivial components exist (each
-/// component is a sorted vec of original 1-based session IDs paired with the
-/// corresponding sub-session slice). Returns `None` when decomposition
-/// provides no benefit (0 or 1 non-trivial components).
+/// Returns `Some(components)` when 2+ components exist (each component is a
+/// sorted vec of original 1-based session IDs paired with the corresponding
+/// sub-session slice). Returns `None` when decomposition provides no benefit
+/// (0 or 1 components).
 #[allow(clippy::type_complexity)]
 fn decompose_sessions<Variable, Version>(
     po: &AtomicTransactionPO<Variable>,
@@ -183,10 +183,7 @@ where
     let comm_graph = communication_graph(po);
     let all_components = connected_components(&comm_graph);
 
-    let components_to_check: Vec<BTreeSet<u64>> = all_components
-        .into_iter()
-        .filter(|c| c.len() >= 2)
-        .collect();
+    let components_to_check: Vec<BTreeSet<u64>> = all_components;
 
     if components_to_check.len() <= 1 {
         return None;

--- a/crates/sat/src/lib.rs
+++ b/crates/sat/src/lib.rs
@@ -231,11 +231,13 @@ fn singleton_commit_order_witness<Variable, Version>(
     sessions: &[Session<Variable, Version>],
 ) -> Witness {
     debug_assert_eq!(sessions.len(), 1);
-    let commit_order: Vec<TransactionId> = (0..)
-        .zip(sessions[0].iter())
+    let commit_order: Vec<TransactionId> = sessions[0]
+        .iter()
+        .enumerate()
         .map(|(session_height, _)| TransactionId {
             session_id: 1,
-            session_height,
+            #[allow(clippy::cast_possible_truncation)]
+            session_height: session_height as u64,
         })
         .collect();
     Witness::CommitOrder(commit_order)
@@ -247,11 +249,13 @@ fn singleton_split_commit_order_witness<Variable, Version>(
 ) -> Witness {
     debug_assert_eq!(sessions.len(), 1);
     Witness::SplitCommitOrder(
-        (0..)
-            .zip(sessions[0].iter())
+        sessions[0]
+            .iter()
+            .enumerate()
             .map(|(session_height, _)| TransactionId {
                 session_id: 1,
-                session_height,
+                #[allow(clippy::cast_possible_truncation)]
+                session_height: session_height as u64,
             })
             .flat_map(|tid| [(tid, false), (tid, true)])
             .collect(),

--- a/crates/sat/src/lib.rs
+++ b/crates/sat/src/lib.rs
@@ -231,13 +231,11 @@ fn singleton_commit_order_witness<Variable, Version>(
     sessions: &[Session<Variable, Version>],
 ) -> Witness {
     debug_assert_eq!(sessions.len(), 1);
-    let commit_order: Vec<TransactionId> = sessions[0]
-        .iter()
-        .enumerate()
+    let commit_order: Vec<TransactionId> = (0..)
+        .zip(sessions[0].iter())
         .map(|(session_height, _)| TransactionId {
             session_id: 1,
-            #[allow(clippy::cast_possible_truncation)]
-            session_height: session_height as u64,
+            session_height,
         })
         .collect();
     Witness::CommitOrder(commit_order)
@@ -249,13 +247,11 @@ fn singleton_split_commit_order_witness<Variable, Version>(
 ) -> Witness {
     debug_assert_eq!(sessions.len(), 1);
     Witness::SplitCommitOrder(
-        sessions[0]
-            .iter()
-            .enumerate()
+        (0..)
+            .zip(sessions[0].iter())
             .map(|(session_height, _)| TransactionId {
                 session_id: 1,
-                #[allow(clippy::cast_possible_truncation)]
-                session_height: session_height as u64,
+                session_height,
             })
             .flat_map(|tid| [(tid, false), (tid, true)])
             .collect(),

--- a/crates/sat/tests/cross_check.rs
+++ b/crates/sat/tests/cross_check.rs
@@ -353,6 +353,16 @@ fn sat_snapshot_witness_preserves_singleton_component() {
 }
 
 #[test]
+fn sat_serializable_decomposition_handles_singleton_component() {
+    let h = two_clusters_plus_singleton_history();
+    assert_agree_ser(&h, "two-clusters-plus-singleton-ser");
+    assert!(
+        check_serializable(&h).is_ok(),
+        "expected SAT-SER pass for decomposed history with singleton component",
+    );
+}
+
+#[test]
 fn sat_single_session_serializable_fast_path() {
     let h = single_session_two_txn_history();
     assert!(

--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -61,6 +61,11 @@ For the NP-complete levels, dbcop first runs the causal checker (as a
 prerequisite), then searches for a valid linearization using depth-first search
 over topological orderings.
 
+Complexity note: Worst-case complexity is NP-complete when the number of
+sessions is unbounded. However, with a bounded number of sessions,
+frontier-memoized search is polynomial in history size because the number of
+distinct frontier states is polynomially bounded by per-session progress states.
+
 ### The Solver Trait
 
 The `ConstrainedLinearizationSolver` trait (`constrained_linearization.rs`)

--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -62,9 +62,19 @@ prerequisite), then searches for a valid linearization using depth-first search
 over topological orderings.
 
 Complexity note: Worst-case complexity is NP-complete when the number of
-sessions is unbounded. However, with a bounded number of sessions,
-frontier-memoized search is polynomial in history size because the number of
-distinct frontier states is polynomially bounded by per-session progress states.
+sessions is unbounded.
+
+For bounded session count `k`, let `n` be the history size. A frontier state is
+determined by per-session progress (and phase bits for split solvers), so the
+number of distinct frontier states is polynomial:
+
+- non-split solvers: `O(n^k)`
+- split solvers: `O((2n)^k) = O(n^k)` for fixed `k`
+
+The bounded-session check can be viewed as reachability in this frontier-state
+transition graph. Reachability (ST-REACH) is the canonical NL problem on the
+explicit graph, so this gives an NL-style formulation; with fixed `k` this is
+also polynomial-time in `n`.
 
 ### The Solver Trait
 

--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -134,8 +134,9 @@ k_i are the component sizes. For histories where sessions interact sparsely
 small, fast checks.
 
 Applied only to NP-complete levels (Prefix, Snapshot Isolation, Serializable).
-The polynomial saturation checkers are already efficient enough without
-decomposition.
+Singleton components are handled via a trivial witness fast-path (no DFS/SAT
+search) after the causal prerequisite check. The polynomial saturation checkers
+are already efficient enough without decomposition.
 
 ## SAT Encoding (Alternative Solver)
 

--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -48,9 +48,8 @@ reads across variables.
 ### Causal (`causal.rs`)
 
 Extends atomic-read with transitivity: the visibility relation must be
-transitively closed. Additionally enforces write-write ordering (`causal_ww`)
-and read-write ordering (`causal_rw`) constraints. Uses incremental transitive
-closure for efficiency.
+transitively closed. It enforces write-write ordering (`causal_ww`) constraints
+to saturation fixed point, using incremental transitive closure for efficiency.
 
 ## Constrained Linearization (NP-Complete Checkers)
 
@@ -69,9 +68,10 @@ defines the DFS framework:
 
 ```
 trait ConstrainedLinearizationSolver {
-    fn allow_next(&self, next: &TransactionId) -> bool;
-    fn forward_book_keeping(&mut self, next: &TransactionId);
-    fn backtrack_book_keeping(&mut self, next: &TransactionId);
+    type Vertex;
+    fn allow_next(&self, linearization: &[Self::Vertex], next: &Self::Vertex) -> bool;
+    fn forward_book_keeping(&mut self, linearization: &[Self::Vertex]);
+    fn backtrack_book_keeping(&mut self, linearization: &[Self::Vertex]);
 }
 ```
 


### PR DESCRIPTION
## Summary
- include singleton communication-graph components during NPC decomposition in core and SAT paths
- preserve complete Prefix/SnapshotIsolation/Serializable witnesses after component remap/merge
- add regressions for singleton-session witness coverage
- update docs/AGENTS to reflect behavior

## Verification
- cargo +nightly fmt --all
- cargo test --workspace
- cargo clippy -p dbcop_core -- -D warnings
- cargo clippy -p dbcop_sat -- -D warnings
- cargo build -p dbcop_core --no-default-features