### PR TITLE
refactor(core): switch NPC decomposition to biconnected blocks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -329,12 +329,11 @@ notepads, and agent memory.
   clones per iteration.
 
 - Communication graph decomposition (`consistency/mod.rs`, `dbcop_sat/lib.rs`):
-  decomposes history by connected components of the communication graph (Theorem
-  5.2 from Biswas & Enea 2019). Checks each component independently, then remaps
-  and merges witnesses. Decomposition must include singleton components as well,
-  otherwise merged Prefix/SI/Serializable witnesses can drop isolated sessions.
-  Reduces DFS/SAT search space from O(n!) to O(sum of k_i!) where k_i are
-  component sizes. Applied to NP-complete levels only: Prefix,
+  decomposes history by biconnected components of the communication graph
+  (Theorem 5.2 from Biswas & Enea 2019). For disjoint components, checks each
+  independently then remaps/merges witnesses. For articulation-overlap
+  components, falls back to a full solve so witness construction never drops
+  external writer context. Applied to NP-complete levels only: Prefix,
   SnapshotIsolation, Serializable.
 - Singleton NPC fast-path (`consistency/mod.rs`, `dbcop_sat/lib.rs`): when the
   projected history has exactly one session, skip DFS/SAT linearization search
@@ -364,9 +363,10 @@ notepads, and agent memory.
   `test_inconsistent_local_read_before_write`.
 - `crates/core/tests/paper_polynomial.rs` -- 13 tests verifying polynomial-time
   checker correctness against known histories.
-- `crates/core/tests/decomposition_check.rs` -- 9 tests verifying communication
-  graph decomposition in NP-complete checkers, including singleton-component
-  witness preservation and single-session trivial witnesses for
+- `crates/core/tests/decomposition_check.rs` -- regression tests verifying
+  communication graph decomposition in NP-complete checkers, including
+  singleton-component witness preservation, biconnected-overlap witness
+  de-duplication, and single-session trivial witnesses for
   Prefix/SI/Serializable.
 - `crates/sat/tests/cross_check.rs` includes SAT witness regression tests for
   singleton-component preservation and single-session fast-path coverage in

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -69,8 +69,8 @@ Result<Witness, Error>         ── crates/core/src/consistency/mod.rs
 - `linearization/` -- NP-complete checkers: `constrained_linearization.rs` (DFS
   solver trait + Zobrist hashing), `prefix.rs`, `snapshot_isolation.rs`,
   `serializable.rs`.
-- `decomposition.rs` -- Communication graph construction and connected component
-  extraction (Theorem 5.2 from Biswas & Enea 2019).
+- `decomposition.rs` -- Communication graph construction and biconnected
+  component extraction (Theorem 5.2 from Biswas & Enea 2019).
 - `witness.rs` -- `Witness` enum: `CommitOrder`, `SplitCommitOrder`,
   `SaturationOrder`.
 - `error.rs` -- `Error` enum: `NonAtomic`, `Invalid`, `Cycle`.


### PR DESCRIPTION
## Summary
- switch communication-graph decomposition used by NPC solvers from connected components to biconnected components
- keep singleton/disjoint component witness merge behavior unchanged
- add safe fallback: when biconnected components overlap on articulation sessions, solve on the full PO to emit a non-duplicated witness
- add regression tests for articulation-overlap histories in both core and SAT checkers
- update algorithm/architecture docs and AGENTS notes to reflect biconnected decomposition behavior

## Validation
- cargo +nightly fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p dbcop_core
- cargo test -p dbcop_sat
- cargo test -p dbcop_core --test decomposition_check
- cargo test -p dbcop_sat --test cross_check