### PR TITLE
perf(core): add trait-driven DFS search policy hooks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,8 +273,8 @@ present for visualization. On invalid input: `{"ok": false, "error": "..."}`.
   policy for NPC solvers. Options include memoization/nogood toggles,
   legal-first frontier ordering (`prefer_allowed_first`), dominance pruning
   mode, tie-breaking mode, restart policy (`restart_max_attempts`,
-  `restart_node_budget`), adaptive portfolio mode, and branch ordering
-  (`AsProvided`, `HighScoreFirst`, `LowScoreFirst`).
+  `restart_node_budget`), adaptive portfolio mode, principal variation mode, and
+  branch ordering (`AsProvided`, `HighScoreFirst`, `LowScoreFirst`).
 
 - `check()` entry point: returns `Result<Witness, Error<Variable, Version>>`.
   Each consistency level produces a specific `Witness` variant on success:
@@ -374,6 +374,14 @@ notepads, and agent memory.
 - Adaptive heuristic portfolio (`constrained_linearization.rs`): restart
   attempts choose among multiple ordering modes (solver-biased, frontier-heavy,
   diverse) using online per-mode stats.
+
+- Principal variation ordering (`constrained_linearization.rs`): restart
+  attempts carry forward the deepest path reached so far and prioritize that PV
+  move at each depth on subsequent attempts.
+
+- Counter-move heuristic (`constrained_linearization.rs`): DFS learns
+  parent→response move pairs from successful recursion paths and boosts the
+  learned reply when the same parent move appears again.
 
 - Chain closure (`atomic/mod.rs`): computes session-order transitive closure
   with an O(S * T^2) forward scan grouped by session. Replaces general

--- a/crates/core/src/consistency/linearization/constrained_linearization.rs
+++ b/crates/core/src/consistency/linearization/constrained_linearization.rs
@@ -27,11 +27,9 @@
 //! # Memoization
 //!
 //! To avoid re-exploring equivalent frontier states reached via
-//! different orderings, the solver maintains a `seen` set of Zobrist
-//! hashes. Each frontier state is hashed by XOR-ing per-vertex random
-//! u128 values, giving O(1) hash updates on vertex add/remove. This
-//! replaces a naive `HashSet<BTreeSet<Vertex>>` approach that would
-//! cost O(T log T) per state.
+//! different orderings, the solver can maintain a `seen` set of
+//! Zobrist-hashed frontier signatures. Hash updates are incremental on
+//! vertex add/remove from the frontier.
 //!
 //! # Trait contract
 //!
@@ -39,6 +37,7 @@
 //!
 //! - [`Vertex`] -- the type of graph nodes (e.g. `TransactionId` or
 //!   `(TransactionId, bool)` for split-phase solvers).
+//! - [`search_options`] -- DFS/memoization/ordering policy.
 //! - [`get_root`] -- the root vertex (typically `TransactionId::default()`).
 //! - [`children_of`] -- successors in the visibility graph.
 //! - [`vertices`] -- all vertices in the graph.
@@ -47,14 +46,17 @@
 //!   placed in the linearization.
 //! - [`backtrack_book_keeping`] -- undo solver state when a vertex is
 //!   removed during backtracking.
+//! - [`zobrist_value`] -- provider-controlled Zobrist token generation.
 //!
 //! [`Vertex`]: ConstrainedLinearizationSolver::Vertex
+//! [`search_options`]: ConstrainedLinearizationSolver::search_options
 //! [`get_root`]: ConstrainedLinearizationSolver::get_root
 //! [`children_of`]: ConstrainedLinearizationSolver::children_of
 //! [`vertices`]: ConstrainedLinearizationSolver::vertices
 //! [`allow_next`]: ConstrainedLinearizationSolver::allow_next
 //! [`forward_book_keeping`]: ConstrainedLinearizationSolver::forward_book_keeping
 //! [`backtrack_book_keeping`]: ConstrainedLinearizationSolver::backtrack_book_keeping
+//! [`zobrist_value`]: ConstrainedLinearizationSolver::zobrist_value
 
 use alloc::collections::vec_deque::VecDeque;
 use alloc::vec::Vec;
@@ -63,13 +65,42 @@ use core::hash::Hash;
 
 use hashbrown::{HashMap, HashSet};
 
+/// Branch-ordering mode for DFS frontier exploration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BranchOrdering {
+    /// Keep frontier order as provided.
+    AsProvided,
+    /// Try higher-scoring candidates first.
+    HighScoreFirst,
+    /// Try lower-scoring candidates first.
+    LowScoreFirst,
+}
+
+/// DFS engine options.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DfsSearchOptions {
+    /// Enable frontier-signature memoization.
+    pub memoize_frontier: bool,
+    /// Candidate ordering strategy.
+    pub branch_ordering: BranchOrdering,
+}
+
+impl Default for DfsSearchOptions {
+    fn default() -> Self {
+        Self {
+            memoize_frontier: true,
+            branch_ordering: BranchOrdering::AsProvided,
+        }
+    }
+}
+
 /// Compute a Zobrist hash value for a vertex.
 ///
 /// Produces a u128 by hashing the vertex with two different seeds and
 /// combining the results. Used for O(1) incremental frontier hashing:
 /// XOR-ing in a vertex when it enters the frontier and XOR-ing it out
 /// when it leaves.
-fn zobrist_value<T: Hash>(v: &T) -> u128 {
+fn default_zobrist_value<T: Hash>(v: &T) -> u128 {
     use core::hash::{BuildHasher, Hasher};
 
     use hashbrown::DefaultHashBuilder;
@@ -105,6 +136,43 @@ pub trait ConstrainedLinearizationSolver {
     /// `(TransactionId, bool)` where the bool distinguishes the read
     /// phase (`false`) from the write phase (`true`).
     type Vertex: Hash + Ord + Eq + Clone + Debug;
+
+    /// Return DFS engine options for this solver.
+    fn search_options(&self) -> DfsSearchOptions {
+        DfsSearchOptions::default()
+    }
+
+    /// Rank a frontier candidate for optional branch ordering.
+    ///
+    /// Default score prefers nodes with larger out-degree (more
+    /// constraining successors).
+    fn branch_score(&self, _linearization: &[Self::Vertex], v: &Self::Vertex) -> i64 {
+        #[allow(clippy::cast_possible_wrap)]
+        self.children_of(v)
+            .map_or(0, |children| children.len() as i64)
+    }
+
+    /// Return the per-vertex Zobrist token used by frontier hashing.
+    ///
+    /// Implementors may override this to provide custom/randomized keys.
+    fn zobrist_value(&self, v: &Self::Vertex) -> u128 {
+        default_zobrist_value(v)
+    }
+
+    /// Build the memoization signature for the current DFS state.
+    ///
+    /// Default uses frontier hash only. Implementors may include
+    /// solver-specific state fingerprints for stronger pruning.
+    fn frontier_signature(&self, frontier_hash: u128, _linearization: &[Self::Vertex]) -> u128 {
+        frontier_hash
+    }
+
+    /// Optional solver-defined branch pruning hook.
+    ///
+    /// Returning `true` prunes the current DFS branch immediately.
+    fn should_prune(&self, _linearization: &[Self::Vertex], _frontier_len: usize) -> bool {
+        false
+    }
 
     /// Return the root vertex of the visibility graph.
     ///
@@ -168,63 +236,103 @@ pub trait ConstrainedLinearizationSolver {
         seen: &mut HashSet<u128>,
         frontier_hash: &mut u128,
     ) -> bool {
-        // println!("explored {}", seen.len());
-        if !seen.insert(*frontier_hash) {
-            // seen is not modified
-            // non-det choices are already explored
-            false
-        } else if non_det_choices.is_empty() {
+        let options = self.search_options();
+
+        if self.should_prune(linearization, non_det_choices.len()) {
+            return false;
+        }
+
+        if options.memoize_frontier {
+            let signature = self.frontier_signature(*frontier_hash, linearization);
+            if !seen.insert(signature) {
+                return false;
+            }
+        }
+
+        if non_det_choices.is_empty() {
             true
         } else {
             let curr_non_det_choices = non_det_choices.len();
-            for _ in 0..curr_non_det_choices {
-                if let Some(u) = non_det_choices.pop_front() {
-                    if self.allow_next(linearization, &u) {
-                        // access it again
-                        if let Some(vs) = self.children_of(&u) {
-                            for v in vs {
-                                let entry = active_parent
-                                    .get_mut(&v)
-                                    .expect("all vertices are expected in active parent");
-                                *entry -= 1;
-                                if *entry == 0 {
-                                    non_det_choices.push_back(v);
-                                }
-                            }
-                        }
+            let mut candidates: Vec<Self::Vertex> = non_det_choices
+                .iter()
+                .take(curr_non_det_choices)
+                .cloned()
+                .collect();
 
-                        linearization.push(u.clone());
-                        *frontier_hash ^= zobrist_value(&u);
-
-                        self.forward_book_keeping(linearization);
-
-                        if self.do_dfs(
-                            non_det_choices,
-                            active_parent,
-                            linearization,
-                            seen,
-                            frontier_hash,
-                        ) {
-                            return true;
-                        }
-
-                        self.backtrack_book_keeping(linearization);
-
-                        linearization.pop();
-                        *frontier_hash ^= zobrist_value(&u);
-
-                        if let Some(vs) = self.children_of(&u) {
-                            for v in vs {
-                                let entry = active_parent
-                                    .get_mut(&v)
-                                    .expect("all vertices are expected in active parent");
-                                *entry += 1;
-                            }
-                        }
-                        non_det_choices.drain(curr_non_det_choices - 1..);
-                    }
-                    non_det_choices.push_back(u);
+            match options.branch_ordering {
+                BranchOrdering::AsProvided => {}
+                BranchOrdering::HighScoreFirst => {
+                    use core::cmp::Reverse;
+                    candidates.sort_by_key(|v| Reverse(self.branch_score(linearization, v)));
                 }
+                BranchOrdering::LowScoreFirst => {
+                    candidates.sort_by_key(|v| self.branch_score(linearization, v));
+                }
+            }
+
+            for candidate in candidates {
+                let Some(pos) = non_det_choices.iter().position(|v| v == &candidate) else {
+                    continue;
+                };
+                let Some(u) = non_det_choices.remove(pos) else {
+                    continue;
+                };
+
+                if self.allow_next(linearization, &u) {
+                    let mut newly_activated: Vec<Self::Vertex> = Vec::new();
+                    if let Some(vs) = self.children_of(&u) {
+                        for v in vs {
+                            let entry = active_parent
+                                .get_mut(&v)
+                                .expect("all vertices are expected in active parent");
+                            *entry -= 1;
+                            if *entry == 0 {
+                                non_det_choices.push_back(v.clone());
+                                *frontier_hash ^= self.zobrist_value(&v);
+                                newly_activated.push(v);
+                            }
+                        }
+                    }
+
+                    linearization.push(u.clone());
+                    *frontier_hash ^= self.zobrist_value(&u);
+
+                    self.forward_book_keeping(linearization);
+
+                    if self.do_dfs(
+                        non_det_choices,
+                        active_parent,
+                        linearization,
+                        seen,
+                        frontier_hash,
+                    ) {
+                        return true;
+                    }
+
+                    self.backtrack_book_keeping(linearization);
+                    linearization.pop();
+                    *frontier_hash ^= self.zobrist_value(&u);
+
+                    if let Some(vs) = self.children_of(&u) {
+                        for v in vs {
+                            let entry = active_parent
+                                .get_mut(&v)
+                                .expect("all vertices are expected in active parent");
+                            *entry += 1;
+                        }
+                    }
+
+                    for v in newly_activated {
+                        if let Some(activated_pos) = non_det_choices.iter().position(|x| x == &v) {
+                            let removed = non_det_choices
+                                .remove(activated_pos)
+                                .expect("frontier vertex should exist");
+                            *frontier_hash ^= self.zobrist_value(&removed);
+                        }
+                    }
+                }
+
+                non_det_choices.push_back(u);
             }
             false
         }
@@ -264,7 +372,7 @@ pub trait ConstrainedLinearizationSolver {
         active_parent.iter().for_each(|(n, v)| {
             if *v == 0 {
                 non_det_choices.push_back(n.clone());
-                frontier_hash ^= zobrist_value(n);
+                frontier_hash ^= self.zobrist_value(n);
             }
         });
 
@@ -281,5 +389,79 @@ pub trait ConstrainedLinearizationSolver {
         } else {
             Some(linearization)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug)]
+    struct ToySolver {
+        scores: HashMap<u64, i64>,
+        use_custom_zobrist: bool,
+    }
+
+    impl ConstrainedLinearizationSolver for ToySolver {
+        type Vertex = u64;
+
+        fn search_options(&self) -> DfsSearchOptions {
+            DfsSearchOptions {
+                memoize_frontier: true,
+                branch_ordering: BranchOrdering::HighScoreFirst,
+            }
+        }
+
+        fn branch_score(&self, _linearization: &[Self::Vertex], v: &Self::Vertex) -> i64 {
+            *self.scores.get(v).unwrap_or(&0)
+        }
+
+        fn zobrist_value(&self, v: &Self::Vertex) -> u128 {
+            if self.use_custom_zobrist {
+                u128::from(*v) << 1
+            } else {
+                default_zobrist_value(v)
+            }
+        }
+
+        fn get_root(&self) -> Self::Vertex {
+            0
+        }
+
+        fn children_of(&self, _source: &Self::Vertex) -> Option<Vec<Self::Vertex>> {
+            None
+        }
+
+        fn allow_next(&self, _linearization: &[Self::Vertex], _v: &Self::Vertex) -> bool {
+            true
+        }
+
+        fn vertices(&self) -> Vec<Self::Vertex> {
+            vec![1, 2]
+        }
+
+        fn forward_book_keeping(&mut self, _linearization: &[Self::Vertex]) {}
+
+        fn backtrack_book_keeping(&mut self, _linearization: &[Self::Vertex]) {}
+    }
+
+    #[test]
+    fn high_score_branching_picks_high_score_first() {
+        let mut solver = ToySolver {
+            scores: [(1, 1), (2, 10)].into(),
+            use_custom_zobrist: false,
+        };
+        let lin = solver.get_linearization().expect("expected linearization");
+        assert_eq!(lin[0], 2);
+    }
+
+    #[test]
+    fn custom_zobrist_provider_still_finds_linearization() {
+        let mut solver = ToySolver {
+            scores: HashMap::default(),
+            use_custom_zobrist: true,
+        };
+        let lin = solver.get_linearization().expect("expected linearization");
+        assert_eq!(lin.len(), 2);
     }
 }

--- a/crates/core/src/consistency/linearization/prefix.rs
+++ b/crates/core/src/consistency/linearization/prefix.rs
@@ -48,7 +48,7 @@ use hashbrown::{HashMap, HashSet};
 
 use crate::consistency::constrained_linearization::{
     seeded_hash_u128, BranchOrdering, ConstrainedLinearizationSolver, DfsSearchOptions,
-    DominancePruning, NogoodLearning,
+    DominancePruning, NogoodLearning, TieBreaking,
 };
 use crate::history::atomic::types::TransactionId;
 use crate::history::atomic::AtomicTransactionPO;
@@ -103,6 +103,9 @@ where
             nogood_learning: NogoodLearning::Enabled,
             enable_killer_history: true,
             dominance_pruning: DominancePruning::Enabled,
+            tie_breaking: TieBreaking::Randomized,
+            restart_max_attempts: 2,
+            restart_node_budget: Some(20_000),
             prefer_allowed_first: true,
             branch_ordering: BranchOrdering::HighScoreFirst,
         }

--- a/crates/core/src/consistency/linearization/prefix.rs
+++ b/crates/core/src/consistency/linearization/prefix.rs
@@ -48,7 +48,7 @@ use hashbrown::{HashMap, HashSet};
 
 use crate::consistency::constrained_linearization::{
     seeded_hash_u128, BranchOrdering, ConstrainedLinearizationSolver, DfsSearchOptions,
-    NogoodLearning,
+    DominancePruning, NogoodLearning,
 };
 use crate::history::atomic::types::TransactionId;
 use crate::history::atomic::AtomicTransactionPO;
@@ -102,6 +102,7 @@ where
             memoize_frontier: true,
             nogood_learning: NogoodLearning::Enabled,
             enable_killer_history: true,
+            dominance_pruning: DominancePruning::Enabled,
             prefer_allowed_first: true,
             branch_ordering: BranchOrdering::HighScoreFirst,
         }

--- a/crates/core/src/consistency/linearization/prefix.rs
+++ b/crates/core/src/consistency/linearization/prefix.rs
@@ -48,7 +48,7 @@ use hashbrown::{HashMap, HashSet};
 
 use crate::consistency::constrained_linearization::{
     seeded_hash_u128, BranchOrdering, ConstrainedLinearizationSolver, DfsSearchOptions,
-    DominancePruning, NogoodLearning, TieBreaking,
+    DominancePruning, HeuristicPortfolio, NogoodLearning, TieBreaking,
 };
 use crate::history::atomic::types::TransactionId;
 use crate::history::atomic::AtomicTransactionPO;
@@ -106,6 +106,7 @@ where
             tie_breaking: TieBreaking::Randomized,
             restart_max_attempts: 2,
             restart_node_budget: Some(20_000),
+            heuristic_portfolio: HeuristicPortfolio::Enabled,
             prefer_allowed_first: true,
             branch_ordering: BranchOrdering::HighScoreFirst,
         }

--- a/crates/core/src/consistency/linearization/prefix.rs
+++ b/crates/core/src/consistency/linearization/prefix.rs
@@ -48,7 +48,7 @@ use hashbrown::{HashMap, HashSet};
 
 use crate::consistency::constrained_linearization::{
     seeded_hash_u128, BranchOrdering, ConstrainedLinearizationSolver, DfsSearchOptions,
-    DominancePruning, HeuristicPortfolio, NogoodLearning, TieBreaking,
+    DominancePruning, HeuristicPortfolio, NogoodLearning, PrincipalVariationOrdering, TieBreaking,
 };
 use crate::history::atomic::types::TransactionId;
 use crate::history::atomic::AtomicTransactionPO;
@@ -107,6 +107,7 @@ where
             restart_max_attempts: 2,
             restart_node_budget: Some(20_000),
             heuristic_portfolio: HeuristicPortfolio::Enabled,
+            principal_variation_ordering: PrincipalVariationOrdering::Enabled,
             prefer_allowed_first: true,
             branch_ordering: BranchOrdering::HighScoreFirst,
         }

--- a/crates/core/src/consistency/linearization/prefix.rs
+++ b/crates/core/src/consistency/linearization/prefix.rs
@@ -99,6 +99,7 @@ where
     fn search_options(&self) -> DfsSearchOptions {
         DfsSearchOptions {
             memoize_frontier: true,
+            enable_killer_history: true,
             prefer_allowed_first: true,
             branch_ordering: BranchOrdering::HighScoreFirst,
         }

--- a/crates/core/src/consistency/linearization/prefix.rs
+++ b/crates/core/src/consistency/linearization/prefix.rs
@@ -104,10 +104,33 @@ where
     }
 
     fn branch_score(&self, _linearization: &[Self::Vertex], v: &Self::Vertex) -> i64 {
+        let txn_info = self.history.history.0.get(&v.0).unwrap();
         let child_count = self.children_of(v).map_or(0, |children| children.len());
         let child_score = i64::try_from(child_count).expect("child count fits i64");
-        let write_bias = i64::from(u8::from(v.1));
-        (child_score * 2) + write_bias
+        let unresolved_readers = txn_info
+            .reads
+            .keys()
+            .filter(|x| {
+                self.active_write
+                    .get(*x)
+                    .is_some_and(|ts| ts.contains(&v.0))
+            })
+            .count();
+        let unresolved_readers_score =
+            i64::try_from(unresolved_readers).expect("unresolved reader count fits i64");
+        let write_release_count = txn_info
+            .writes
+            .iter()
+            .filter(|x| {
+                self.active_write
+                    .get(*x)
+                    .is_some_and(|ts| ts.len() == 1 && ts.contains(&v.0))
+            })
+            .count();
+        let write_release_score =
+            i64::try_from(write_release_count).expect("write release count fits i64");
+        let write_bias = i64::from(u8::from(v.1)) * 2;
+        (unresolved_readers_score * 8) + (write_release_score * 4) + (child_score * 2) + write_bias
     }
 
     fn frontier_signature(&self, frontier_hash: u128, _linearization: &[Self::Vertex]) -> u128 {

--- a/crates/core/src/consistency/linearization/prefix.rs
+++ b/crates/core/src/consistency/linearization/prefix.rs
@@ -99,6 +99,7 @@ where
     fn search_options(&self) -> DfsSearchOptions {
         DfsSearchOptions {
             memoize_frontier: true,
+            prefer_allowed_first: true,
             branch_ordering: BranchOrdering::HighScoreFirst,
         }
     }

--- a/crates/core/src/consistency/linearization/prefix.rs
+++ b/crates/core/src/consistency/linearization/prefix.rs
@@ -48,6 +48,7 @@ use hashbrown::{HashMap, HashSet};
 
 use crate::consistency::constrained_linearization::{
     seeded_hash_u128, BranchOrdering, ConstrainedLinearizationSolver, DfsSearchOptions,
+    NogoodLearning,
 };
 use crate::history::atomic::types::TransactionId;
 use crate::history::atomic::AtomicTransactionPO;
@@ -99,6 +100,7 @@ where
     fn search_options(&self) -> DfsSearchOptions {
         DfsSearchOptions {
             memoize_frontier: true,
+            nogood_learning: NogoodLearning::Enabled,
             enable_killer_history: true,
             prefer_allowed_first: true,
             branch_ordering: BranchOrdering::HighScoreFirst,

--- a/crates/core/src/consistency/linearization/prefix.rs
+++ b/crates/core/src/consistency/linearization/prefix.rs
@@ -46,7 +46,9 @@ use core::hash::Hash;
 
 use hashbrown::{HashMap, HashSet};
 
-use crate::consistency::constrained_linearization::ConstrainedLinearizationSolver;
+use crate::consistency::constrained_linearization::{
+    BranchOrdering, ConstrainedLinearizationSolver, DfsSearchOptions,
+};
 use crate::history::atomic::types::TransactionId;
 use crate::history::atomic::AtomicTransactionPO;
 
@@ -93,6 +95,21 @@ where
     Variable: Clone + Eq + Ord + Hash,
 {
     type Vertex = (TransactionId, bool);
+
+    fn search_options(&self) -> DfsSearchOptions {
+        DfsSearchOptions {
+            memoize_frontier: true,
+            branch_ordering: BranchOrdering::HighScoreFirst,
+        }
+    }
+
+    fn branch_score(&self, _linearization: &[Self::Vertex], v: &Self::Vertex) -> i64 {
+        let child_count = self.children_of(v).map_or(0, |children| children.len());
+        let child_score = i64::try_from(child_count).expect("child count fits i64");
+        let write_bias = i64::from(u8::from(v.1));
+        (child_score * 2) + write_bias
+    }
+
     fn get_root(&self) -> Self::Vertex {
         // Transaction is partitioned into read and write section
         // (TransactionId, false): read section

--- a/crates/core/src/consistency/linearization/serializable.rs
+++ b/crates/core/src/consistency/linearization/serializable.rs
@@ -49,6 +49,7 @@ use hashbrown::{HashMap, HashSet};
 
 use crate::consistency::constrained_linearization::{
     seeded_hash_u128, BranchOrdering, ConstrainedLinearizationSolver, DfsSearchOptions,
+    NogoodLearning,
 };
 use crate::history::atomic::types::TransactionId;
 use crate::history::atomic::AtomicTransactionPO;
@@ -101,6 +102,7 @@ where
     fn search_options(&self) -> DfsSearchOptions {
         DfsSearchOptions {
             memoize_frontier: true,
+            nogood_learning: NogoodLearning::Enabled,
             enable_killer_history: true,
             prefer_allowed_first: true,
             branch_ordering: BranchOrdering::HighScoreFirst,

--- a/crates/core/src/consistency/linearization/serializable.rs
+++ b/crates/core/src/consistency/linearization/serializable.rs
@@ -49,7 +49,7 @@ use hashbrown::{HashMap, HashSet};
 
 use crate::consistency::constrained_linearization::{
     seeded_hash_u128, BranchOrdering, ConstrainedLinearizationSolver, DfsSearchOptions,
-    DominancePruning, NogoodLearning, TieBreaking,
+    DominancePruning, HeuristicPortfolio, NogoodLearning, TieBreaking,
 };
 use crate::history::atomic::types::TransactionId;
 use crate::history::atomic::AtomicTransactionPO;
@@ -108,6 +108,7 @@ where
             tie_breaking: TieBreaking::Randomized,
             restart_max_attempts: 2,
             restart_node_budget: Some(20_000),
+            heuristic_portfolio: HeuristicPortfolio::Enabled,
             prefer_allowed_first: true,
             branch_ordering: BranchOrdering::HighScoreFirst,
         }

--- a/crates/core/src/consistency/linearization/serializable.rs
+++ b/crates/core/src/consistency/linearization/serializable.rs
@@ -49,7 +49,7 @@ use hashbrown::{HashMap, HashSet};
 
 use crate::consistency::constrained_linearization::{
     seeded_hash_u128, BranchOrdering, ConstrainedLinearizationSolver, DfsSearchOptions,
-    DominancePruning, HeuristicPortfolio, NogoodLearning, TieBreaking,
+    DominancePruning, HeuristicPortfolio, NogoodLearning, PrincipalVariationOrdering, TieBreaking,
 };
 use crate::history::atomic::types::TransactionId;
 use crate::history::atomic::AtomicTransactionPO;
@@ -109,6 +109,7 @@ where
             restart_max_attempts: 2,
             restart_node_budget: Some(20_000),
             heuristic_portfolio: HeuristicPortfolio::Enabled,
+            principal_variation_ordering: PrincipalVariationOrdering::Enabled,
             prefer_allowed_first: true,
             branch_ordering: BranchOrdering::HighScoreFirst,
         }

--- a/crates/core/src/consistency/linearization/serializable.rs
+++ b/crates/core/src/consistency/linearization/serializable.rs
@@ -49,7 +49,7 @@ use hashbrown::{HashMap, HashSet};
 
 use crate::consistency::constrained_linearization::{
     seeded_hash_u128, BranchOrdering, ConstrainedLinearizationSolver, DfsSearchOptions,
-    DominancePruning, NogoodLearning,
+    DominancePruning, NogoodLearning, TieBreaking,
 };
 use crate::history::atomic::types::TransactionId;
 use crate::history::atomic::AtomicTransactionPO;
@@ -105,6 +105,9 @@ where
             nogood_learning: NogoodLearning::Enabled,
             enable_killer_history: true,
             dominance_pruning: DominancePruning::Enabled,
+            tie_breaking: TieBreaking::Randomized,
+            restart_max_attempts: 2,
+            restart_node_budget: Some(20_000),
             prefer_allowed_first: true,
             branch_ordering: BranchOrdering::HighScoreFirst,
         }

--- a/crates/core/src/consistency/linearization/serializable.rs
+++ b/crates/core/src/consistency/linearization/serializable.rs
@@ -101,6 +101,7 @@ where
     fn search_options(&self) -> DfsSearchOptions {
         DfsSearchOptions {
             memoize_frontier: true,
+            enable_killer_history: true,
             prefer_allowed_first: true,
             branch_ordering: BranchOrdering::HighScoreFirst,
         }

--- a/crates/core/src/consistency/linearization/serializable.rs
+++ b/crates/core/src/consistency/linearization/serializable.rs
@@ -101,6 +101,7 @@ where
     fn search_options(&self) -> DfsSearchOptions {
         DfsSearchOptions {
             memoize_frontier: true,
+            prefer_allowed_first: true,
             branch_ordering: BranchOrdering::HighScoreFirst,
         }
     }

--- a/crates/core/src/consistency/linearization/serializable.rs
+++ b/crates/core/src/consistency/linearization/serializable.rs
@@ -48,7 +48,7 @@ use core::hash::Hash;
 use hashbrown::{HashMap, HashSet};
 
 use crate::consistency::constrained_linearization::{
-    BranchOrdering, ConstrainedLinearizationSolver, DfsSearchOptions,
+    seeded_hash_u128, BranchOrdering, ConstrainedLinearizationSolver, DfsSearchOptions,
 };
 use crate::history::atomic::types::TransactionId;
 use crate::history::atomic::AtomicTransactionPO;
@@ -116,6 +116,21 @@ where
         let child_score = i64::try_from(child_count).expect("child count fits i64");
         let write_score = i64::try_from(write_set).expect("write count fits i64");
         child_score + (write_score * 2)
+    }
+
+    fn frontier_signature(&self, frontier_hash: u128, _linearization: &[Self::Vertex]) -> u128 {
+        let mut signature = frontier_hash;
+        for (var, readers) in &self.active_write {
+            let mut readers_mix = 0_u128;
+            for reader in readers {
+                readers_mix ^= seeded_hash_u128(0x701, reader);
+            }
+            let var_mix = seeded_hash_u128(0x702, var);
+            let reader_count = u64::try_from(readers.len()).expect("reader count fits u64");
+            let count_mix = seeded_hash_u128(0x703, &reader_count);
+            signature ^= var_mix ^ readers_mix ^ count_mix;
+        }
+        signature
     }
 
     fn get_root(&self) -> Self::Vertex {

--- a/crates/core/src/consistency/linearization/serializable.rs
+++ b/crates/core/src/consistency/linearization/serializable.rs
@@ -49,7 +49,7 @@ use hashbrown::{HashMap, HashSet};
 
 use crate::consistency::constrained_linearization::{
     seeded_hash_u128, BranchOrdering, ConstrainedLinearizationSolver, DfsSearchOptions,
-    NogoodLearning,
+    DominancePruning, NogoodLearning,
 };
 use crate::history::atomic::types::TransactionId;
 use crate::history::atomic::AtomicTransactionPO;
@@ -104,6 +104,7 @@ where
             memoize_frontier: true,
             nogood_learning: NogoodLearning::Enabled,
             enable_killer_history: true,
+            dominance_pruning: DominancePruning::Enabled,
             prefer_allowed_first: true,
             branch_ordering: BranchOrdering::HighScoreFirst,
         }

--- a/crates/core/src/consistency/linearization/snapshot_isolation.rs
+++ b/crates/core/src/consistency/linearization/snapshot_isolation.rs
@@ -50,6 +50,7 @@ use hashbrown::{HashMap, HashSet};
 
 use crate::consistency::constrained_linearization::{
     seeded_hash_u128, BranchOrdering, ConstrainedLinearizationSolver, DfsSearchOptions,
+    NogoodLearning,
 };
 use crate::history::atomic::types::TransactionId;
 use crate::history::atomic::AtomicTransactionPO;
@@ -109,6 +110,7 @@ where
     fn search_options(&self) -> DfsSearchOptions {
         DfsSearchOptions {
             memoize_frontier: true,
+            nogood_learning: NogoodLearning::Enabled,
             enable_killer_history: true,
             prefer_allowed_first: true,
             branch_ordering: BranchOrdering::HighScoreFirst,

--- a/crates/core/src/consistency/linearization/snapshot_isolation.rs
+++ b/crates/core/src/consistency/linearization/snapshot_isolation.rs
@@ -49,7 +49,7 @@ use core::hash::Hash;
 use hashbrown::{HashMap, HashSet};
 
 use crate::consistency::constrained_linearization::{
-    BranchOrdering, ConstrainedLinearizationSolver, DfsSearchOptions,
+    seeded_hash_u128, BranchOrdering, ConstrainedLinearizationSolver, DfsSearchOptions,
 };
 use crate::history::atomic::types::TransactionId;
 use crate::history::atomic::AtomicTransactionPO;
@@ -118,6 +118,24 @@ where
         let child_score = i64::try_from(child_count).expect("child count fits i64");
         let write_bias = if v.1 { 2 } else { 0 };
         child_score + write_bias
+    }
+
+    fn frontier_signature(&self, frontier_hash: u128, _linearization: &[Self::Vertex]) -> u128 {
+        let mut signature = frontier_hash;
+        for (var, readers) in &self.active_write {
+            let mut readers_mix = 0_u128;
+            for reader in readers {
+                readers_mix ^= seeded_hash_u128(0x601, reader);
+            }
+            let var_mix = seeded_hash_u128(0x602, var);
+            let reader_count = u64::try_from(readers.len()).expect("reader count fits u64");
+            let count_mix = seeded_hash_u128(0x603, &reader_count);
+            signature ^= var_mix ^ readers_mix ^ count_mix;
+        }
+        for var in &self.active_variable {
+            signature ^= seeded_hash_u128(0x604, var);
+        }
+        signature
     }
 
     fn get_root(&self) -> Self::Vertex {

--- a/crates/core/src/consistency/linearization/snapshot_isolation.rs
+++ b/crates/core/src/consistency/linearization/snapshot_isolation.rs
@@ -50,7 +50,7 @@ use hashbrown::{HashMap, HashSet};
 
 use crate::consistency::constrained_linearization::{
     seeded_hash_u128, BranchOrdering, ConstrainedLinearizationSolver, DfsSearchOptions,
-    DominancePruning, HeuristicPortfolio, NogoodLearning, TieBreaking,
+    DominancePruning, HeuristicPortfolio, NogoodLearning, PrincipalVariationOrdering, TieBreaking,
 };
 use crate::history::atomic::types::TransactionId;
 use crate::history::atomic::AtomicTransactionPO;
@@ -117,6 +117,7 @@ where
             restart_max_attempts: 2,
             restart_node_budget: Some(20_000),
             heuristic_portfolio: HeuristicPortfolio::Enabled,
+            principal_variation_ordering: PrincipalVariationOrdering::Enabled,
             prefer_allowed_first: true,
             branch_ordering: BranchOrdering::HighScoreFirst,
         }

--- a/crates/core/src/consistency/linearization/snapshot_isolation.rs
+++ b/crates/core/src/consistency/linearization/snapshot_isolation.rs
@@ -50,7 +50,7 @@ use hashbrown::{HashMap, HashSet};
 
 use crate::consistency::constrained_linearization::{
     seeded_hash_u128, BranchOrdering, ConstrainedLinearizationSolver, DfsSearchOptions,
-    DominancePruning, NogoodLearning,
+    DominancePruning, NogoodLearning, TieBreaking,
 };
 use crate::history::atomic::types::TransactionId;
 use crate::history::atomic::AtomicTransactionPO;
@@ -113,6 +113,9 @@ where
             nogood_learning: NogoodLearning::Enabled,
             enable_killer_history: true,
             dominance_pruning: DominancePruning::Enabled,
+            tie_breaking: TieBreaking::Randomized,
+            restart_max_attempts: 2,
+            restart_node_budget: Some(20_000),
             prefer_allowed_first: true,
             branch_ordering: BranchOrdering::HighScoreFirst,
         }

--- a/crates/core/src/consistency/linearization/snapshot_isolation.rs
+++ b/crates/core/src/consistency/linearization/snapshot_isolation.rs
@@ -109,6 +109,7 @@ where
     fn search_options(&self) -> DfsSearchOptions {
         DfsSearchOptions {
             memoize_frontier: true,
+            prefer_allowed_first: true,
             branch_ordering: BranchOrdering::HighScoreFirst,
         }
     }

--- a/crates/core/src/consistency/linearization/snapshot_isolation.rs
+++ b/crates/core/src/consistency/linearization/snapshot_isolation.rs
@@ -50,7 +50,7 @@ use hashbrown::{HashMap, HashSet};
 
 use crate::consistency::constrained_linearization::{
     seeded_hash_u128, BranchOrdering, ConstrainedLinearizationSolver, DfsSearchOptions,
-    DominancePruning, NogoodLearning, TieBreaking,
+    DominancePruning, HeuristicPortfolio, NogoodLearning, TieBreaking,
 };
 use crate::history::atomic::types::TransactionId;
 use crate::history::atomic::AtomicTransactionPO;
@@ -116,6 +116,7 @@ where
             tie_breaking: TieBreaking::Randomized,
             restart_max_attempts: 2,
             restart_node_budget: Some(20_000),
+            heuristic_portfolio: HeuristicPortfolio::Enabled,
             prefer_allowed_first: true,
             branch_ordering: BranchOrdering::HighScoreFirst,
         }

--- a/crates/core/src/consistency/linearization/snapshot_isolation.rs
+++ b/crates/core/src/consistency/linearization/snapshot_isolation.rs
@@ -109,6 +109,7 @@ where
     fn search_options(&self) -> DfsSearchOptions {
         DfsSearchOptions {
             memoize_frontier: true,
+            enable_killer_history: true,
             prefer_allowed_first: true,
             branch_ordering: BranchOrdering::HighScoreFirst,
         }

--- a/crates/core/src/consistency/linearization/snapshot_isolation.rs
+++ b/crates/core/src/consistency/linearization/snapshot_isolation.rs
@@ -50,7 +50,7 @@ use hashbrown::{HashMap, HashSet};
 
 use crate::consistency::constrained_linearization::{
     seeded_hash_u128, BranchOrdering, ConstrainedLinearizationSolver, DfsSearchOptions,
-    NogoodLearning,
+    DominancePruning, NogoodLearning,
 };
 use crate::history::atomic::types::TransactionId;
 use crate::history::atomic::AtomicTransactionPO;
@@ -112,6 +112,7 @@ where
             memoize_frontier: true,
             nogood_learning: NogoodLearning::Enabled,
             enable_killer_history: true,
+            dominance_pruning: DominancePruning::Enabled,
             prefer_allowed_first: true,
             branch_ordering: BranchOrdering::HighScoreFirst,
         }

--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -115,6 +115,15 @@ visited frontier states to prune the search. Candidate ordering first
 prioritizes currently legal moves (`allow_next = true`), then applies
 `branch_score()` according to `search_options()`.
 
+The current DFS search stack also includes:
+
+- killer/history move ordering (learned move boosts),
+- nogood learning on failed signatures,
+- conflict-directed backjumping with learned jump depths,
+- frontier-dominance pruning at fixed solver-state signature,
+- randomized, budgeted restarts with final exhaustive fallback,
+- adaptive attempt-level heuristic portfolio selection.
+
 ### Prefix (`prefix.rs`)
 
 Splits each transaction into a read phase and a write phase. Finds a

--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -84,6 +84,10 @@ defines the DFS framework:
 ```
 trait ConstrainedLinearizationSolver {
     type Vertex;
+    fn search_options(&self) -> DfsSearchOptions;
+    fn branch_score(&self, linearization: &[Self::Vertex], next: &Self::Vertex) -> i64;
+    fn zobrist_value(&self, next: &Self::Vertex) -> u128;
+    fn should_prune(&self, linearization: &[Self::Vertex], frontier_len: usize) -> bool;
     fn allow_next(&self, linearization: &[Self::Vertex], next: &Self::Vertex) -> bool;
     fn forward_book_keeping(&mut self, linearization: &[Self::Vertex]);
     fn backtrack_book_keeping(&mut self, linearization: &[Self::Vertex]);
@@ -92,6 +96,13 @@ trait ConstrainedLinearizationSolver {
 
 - `allow_next()` -- Can this transaction be appended to the current partial
   linearization?
+- `search_options()` -- Solver-provided DFS policy (memoization and branch
+  ordering mode).
+- `branch_score()` -- Optional heuristic score for frontier ordering (used by
+  high-score/low-score modes).
+- `zobrist_value()` -- Solver-provided Zobrist token source for frontier-state
+  signatures.
+- `should_prune()` -- Optional branch-and-bound style pruning hook.
 - `forward_book_keeping()` -- Update solver state after appending a transaction.
 - `backtrack_book_keeping()` -- Undo state changes when backtracking.
 

--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -118,11 +118,13 @@ prioritizes currently legal moves (`allow_next = true`), then applies
 The current DFS search stack also includes:
 
 - killer/history move ordering (learned move boosts),
+- counter-move ordering (learned parent->response replies),
 - nogood learning on failed signatures,
 - conflict-directed backjumping with learned jump depths,
 - frontier-dominance pruning at fixed solver-state signature,
 - randomized, budgeted restarts with final exhaustive fallback,
-- adaptive attempt-level heuristic portfolio selection.
+- adaptive attempt-level heuristic portfolio selection,
+- principal variation (PV) ordering across restart attempts.
 
 ### Prefix (`prefix.rs`)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,8 +67,9 @@ Result<Witness, Error>         ── crates/core/src/consistency/mod.rs
 - `saturation/` -- Polynomial-time checkers: `committed_read.rs`,
   `atomic_read.rs`, `causal.rs`, `repeatable_read.rs`.
 - `linearization/` -- NP-complete checkers: `constrained_linearization.rs` (DFS
-  solver trait + solver-provided DFS options + Zobrist hashing hooks),
-  `prefix.rs`, `snapshot_isolation.rs`, `serializable.rs`.
+  solver trait + solver-provided DFS options + legal-first move ordering +
+  Zobrist/state-signature memoization hooks), `prefix.rs`,
+  `snapshot_isolation.rs`, `serializable.rs`.
 - `decomposition.rs` -- Communication graph construction and biconnected
   component extraction (Theorem 5.2 from Biswas & Enea 2019).
 - `witness.rs` -- `Witness` enum: `CommitOrder`, `SplitCommitOrder`,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,8 +67,8 @@ Result<Witness, Error>         ── crates/core/src/consistency/mod.rs
 - `saturation/` -- Polynomial-time checkers: `committed_read.rs`,
   `atomic_read.rs`, `causal.rs`, `repeatable_read.rs`.
 - `linearization/` -- NP-complete checkers: `constrained_linearization.rs` (DFS
-  solver trait + Zobrist hashing), `prefix.rs`, `snapshot_isolation.rs`,
-  `serializable.rs`.
+  solver trait + solver-provided DFS options + Zobrist hashing hooks),
+  `prefix.rs`, `snapshot_isolation.rs`, `serializable.rs`.
 - `decomposition.rs` -- Communication graph construction and biconnected
   component extraction (Theorem 5.2 from Biswas & Enea 2019).
 - `witness.rs` -- `Witness` enum: `CommitOrder`, `SplitCommitOrder`,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -69,8 +69,9 @@ Result<Witness, Error>         ── crates/core/src/consistency/mod.rs
 - `linearization/` -- NP-complete checkers: `constrained_linearization.rs` (DFS
   solver trait + solver-provided DFS options + legal-first move ordering +
   Zobrist/state-signature memoization hooks + killer/history + nogood/backjump
-  - dominance pruning + randomized restarts + adaptive portfolio), `prefix.rs`,
-    `snapshot_isolation.rs`, `serializable.rs`.
+  - dominance pruning + randomized restarts + adaptive portfolio + principal
+    variation/counter-move ordering), `prefix.rs`, `snapshot_isolation.rs`,
+    `serializable.rs`.
 - `decomposition.rs` -- Communication graph construction and biconnected
   component extraction (Theorem 5.2 from Biswas & Enea 2019).
 - `witness.rs` -- `Witness` enum: `CommitOrder`, `SplitCommitOrder`,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -68,8 +68,9 @@ Result<Witness, Error>         ── crates/core/src/consistency/mod.rs
   `atomic_read.rs`, `causal.rs`, `repeatable_read.rs`.
 - `linearization/` -- NP-complete checkers: `constrained_linearization.rs` (DFS
   solver trait + solver-provided DFS options + legal-first move ordering +
-  Zobrist/state-signature memoization hooks), `prefix.rs`,
-  `snapshot_isolation.rs`, `serializable.rs`.
+  Zobrist/state-signature memoization hooks + killer/history + nogood/backjump
+  - dominance pruning + randomized restarts + adaptive portfolio), `prefix.rs`,
+    `snapshot_isolation.rs`, `serializable.rs`.
 - `decomposition.rs` -- Communication graph construction and biconnected
   component extraction (Theorem 5.2 from Biswas & Enea 2019).
 - `witness.rs` -- `Witness` enum: `CommitOrder`, `SplitCommitOrder`,


### PR DESCRIPTION
## Summary
- add configurable DFS search policy hooks to `ConstrainedLinearizationSolver`
- expose provider methods for branch ordering/scoring, pruning, and frontier signature
- make Zobrist token generation provider-controlled via `zobrist_value`
- wire Prefix/SnapshotIsolation/Serializable solvers to use high-score-first branching
- document extension points and performance decisions in `docs/*` and `AGENTS.md`

## Validation
- cargo +nightly fmt --all --check
- cargo clippy -p dbcop_core -- -D warnings
- cargo test -p dbcop_core
