### PR TITLE
chore(ci): improve codecov reporting for rust and deno

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -33,8 +33,15 @@ jobs:
         with:
           tool: cargo-llvm-cov
 
-      - name: Generate coverage report
-        run: cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info
+      - name: Prepare coverage output directories
+        run: |
+          rm -rf coverage
+          mkdir -p coverage
+
+      - name: Generate Rust coverage report (LCOV)
+        run: |
+          cargo llvm-cov clean --workspace
+          cargo llvm-cov --workspace --all-features --lcov --output-path coverage/rust.lcov
 
       - name: Set up Deno
         uses: denoland/setup-deno@v2
@@ -50,9 +57,25 @@ jobs:
 
       - name: Generate Deno LCOV report
         run: deno coverage coverage/deno --lcov --output=coverage/deno.lcov
-      - name: Upload coverage to Codecov
+
+      - name: Upload Rust coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
-          files: lcov.info,coverage/deno.lcov
+          files: coverage/rust.lcov
+          flags: rust
+          name: rust-coverage
+          disable_search: true
           fail_ci_if_error: true
+          verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload Deno coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage/deno.lcov
+          flags: deno
+          name: deno-coverage
+          disable_search: true
+          fail_ci_if_error: true
+          verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ Examples:
   Config: `.github/zizmor.yml` suppresses hash-pin warnings (we use tag-pinned
   refs, not SHA hashes). Fix all other zizmor lints.
 - Coverage:
-  `cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info`.
+  `cargo llvm-cov --workspace --all-features --lcov --output-path coverage/rust.lcov`.
   Requires `llvm-tools-preview` component and `cargo-llvm-cov` installed.
 
 ## CI Checks
@@ -77,8 +77,8 @@ All five must pass before merging:
    files, typos spell check
 4. `Deno` (deno.yaml) -- builds WASM, runs deno fmt/lint/check, runs WASM
    integration tests
-5. `coverage` (coverage.yaml) -- cargo-llvm-cov + Codecov upload (requires
-   `CODECOV_TOKEN` secret)
+5. `coverage` (coverage.yaml) -- cargo-llvm-cov + Deno lcov + split Codecov
+   uploads (flags: `rust`, `deno`; requires `CODECOV_TOKEN` secret)
 
 ## Code Constraints
 
@@ -132,6 +132,8 @@ dbcop/                          workspace root
     rust.yaml                    build + format CI
     code-quality.yaml            taplo + typos CI
     deno.yaml                    Deno fmt/lint/check + WASM tests CI
+    coverage.yaml                Rust + Deno coverage generation and Codecov upload
+  codecov.yml                    Codecov status config (project/patch + rust/deno flags)
   .github/zizmor.yml             zizmor config: suppress hash-pin lint (allow tag-pinned refs)
   .husky/pre-commit              ASCII check + cargo +nightly fmt + deno:ci
   taplo.toml                     TOML formatter config

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,50 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  precision: 2
+  round: down
+  range: "50...100"
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+      rust:
+        flags:
+          - rust
+        target: auto
+        threshold: 1%
+      deno:
+        flags:
+          - deno
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+      rust:
+        flags:
+          - rust
+        target: auto
+        threshold: 1%
+      deno:
+        flags:
+          - deno
+        target: auto
+        threshold: 1%
+
+flags:
+  rust:
+    carryforward: true
+    paths:
+      - crates/
+  deno:
+    carryforward: true
+    paths:
+      - crates/wasm/
+
+ignore:
+  - target/**
+  - wasmlib/**


### PR DESCRIPTION
## Summary
- split coverage upload into two Codecov uploads with explicit flags/components:
  - Rust LCOV: `flags: rust`, `name: rust-coverage`
  - Deno LCOV: `flags: deno`, `name: deno-coverage`
- make coverage generation deterministic by writing reports under `coverage/` and cleaning before generation
- add repository `codecov.yml` to track project/patch status for both rust and deno flags
- update `AGENTS.md` coverage/workflow docs to match the new setup

## Why this improves Codecov
- Rust and Deno coverage are now independently visible and attributable in Codecov
- a failure or regression in one ecosystem no longer obscures the other report
- explicit flags/status checks make regressions easier to triage and enforce in PRs

## Validation
- `deno task deno:fmt`
- `/usr/bin/act --list`
- `zizmor .github/workflows/`
