### PR TITLE
feat(core): expose RepeatableRead consistency level + expand AGENTS.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ wasmlib/
 
 # npm/node artifacts (husky install)
 node_modules/
+
+# Coverage artifacts
+coverage/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,6 @@ All five must pass before merging:
   `#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]`
 - Do NOT rename existing public types (e.g. `CommittedRead` stays
   `CommittedRead`).
-- Do NOT add a `Consistency::RepeatableRead` variant.
 - Do NOT change the `ConstrainedLinearizationSolver` trait API.
 - Raw-history validation must preserve read-your-write semantics within a
   transaction: a local read is valid only when it matches the latest preceding
@@ -181,8 +180,8 @@ The `dbcop` binary has four subcommands: `generate`, `verify`, `fmt`, and
 
 - `--input-dir <DIR>` -- directory containing history JSON files (required)
 - `--consistency <LEVEL>` -- consistency level to check (required). Values:
-  `committed-read`, `atomic-read`, `causal`, `prefix`, `snapshot-isolation`,
-  `serializable`.
+  `committed-read`, `repeatable-read`, `atomic-read`, `causal`, `prefix`,
+  `snapshot-isolation`, `serializable`.
 - `--verbose` -- on PASS prints witness details (Debug format), on FAIL prints
   full error details. Output: `{filename}: PASS\n  witness: {witness:?}` or
   `{filename}: FAIL\n  error: {error:?}`.
@@ -298,8 +297,8 @@ present for visualization. On invalid input: `{"ok": false, "error": "..."}`.
   `wr_union: DiGraph<TransactionId>`,
   `visibility_relation: DiGraph<TransactionId>`.
 
-- `Consistency` enum: `CommittedRead`, `AtomicRead`, `Causal`, `Prefix`,
-  `SnapshotIsolation`, `Serializable`.
+- `Consistency` enum: `CommittedRead`, `RepeatableRead`, `AtomicRead`, `Causal`,
+  `Prefix`, `SnapshotIsolation`, `Serializable`.
 
 - `DfsSearchOptions` / `BranchOrdering`
   (`consistency/linearization/constrained_linearization.rs`): trait-level DFS
@@ -313,6 +312,8 @@ present for visualization. On invalid input: `{"ok": false, "error": "..."}`.
   Each consistency level produces a specific `Witness` variant on success:
   - Committed Read: `SaturationOrder(DiGraph<TransactionId>)` (committed order
     graph)
+  - Repeatable Read: `SaturationOrder(DiGraph<TransactionId>)` (committed order
+    graph)
   - Atomic Read: `SaturationOrder(DiGraph<TransactionId>)` (visibility relation)
   - Causal: `SaturationOrder(DiGraph<TransactionId>)` (visibility relation)
   - Prefix: `CommitOrder(Vec<TransactionId>)` (transaction commit order)
@@ -324,8 +325,8 @@ present for visualization. On invalid input: `{"ok": false, "error": "..."}`.
 - `Witness` enum: returned by `check()` on success. Variants:
   `CommitOrder(Vec<TransactionId>)` (Prefix, Serializable),
   `SplitCommitOrder(Vec<(TransactionId, bool)>)` (SnapshotIsolation),
-  `SaturationOrder(DiGraph<TransactionId>)` (Committed Read, Atomic Read,
-  Causal).
+  `SaturationOrder(DiGraph<TransactionId>)` (Committed Read, Repeatable Read,
+  Atomic Read, Causal).
 
 - `Error<Variable, Version>` enum: returned by `check()` on failure. Variants:
   `NonAtomic(NonAtomicError)` (structural issue like uncommitted writes),

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,15 +127,15 @@ dbcop/                          workspace root
           decomposition.rs          communication graph + biconnected decomposition
           witness.rs                Witness enum (CommitOrder, SplitCommitOrder, SaturationOrder)
           error.rs                  Error enum (NonAtomic, Cycle, Invalid)
-          saturation/              saturation-based checkers (CommittedRead, AtomicRead, Causal)
-            repeatable_read.rs     internal checker (not exposed via Consistency enum)
+          saturation/              saturation-based checkers (CommittedRead, RepeatableRead, AtomicRead, Causal)
+            repeatable_read.rs     Repeatable Read checker
           linearization/           linearization-based checkers (Prefix, SnapshotIsolation, Serializable)
             constrained_linearization.rs  DFS engine + solver trait (1141 lines)
         history/
           raw/                     raw history types (Session, Transaction, Event)
           atomic/                  AtomicTransactionPO and AtomicTransactionHistory
       tests/                      7 integration tests + common/ helper macros
-      benches/                    18 Criterion benchmarks (6 levels x 3 sizes)
+      benches/                    21 Criterion benchmarks (7 levels x 3 sizes)
     cli/                         CLI binary -- dbcop_cli
     wasm/                        WASM bindings -- dbcop_wasm
       tests/
@@ -151,7 +151,7 @@ dbcop/                          workspace root
   docs/
     architecture.md               crate structure, data flow, key types
     algorithms.md                 saturation, linearization, decomposition, SAT encoding
-    consistency-models.md         formal definitions of all six levels
+    consistency-models.md         formal definitions of all seven levels
     cli-reference.md              generate and verify commands, flags, output formats
     history-format.md             JSON schema with annotated examples
     wasm-api.md                   WASM bindings API reference
@@ -228,8 +228,8 @@ The `dbcop_wasm` crate exposes two functions via `wasm_bindgen`:
 
 - `history_json`: JSON-encoded array of sessions (same format as CLI input
   files).
-- `level`: one of `committed-read`, `atomic-read`, `causal`, `prefix`,
-  `snapshot-isolation`, `serializable`.
+- `level`: one of `committed-read`, `repeatable-read`, `atomic-read`, `causal`,
+  `prefix`, `snapshot-isolation`, `serializable`.
 
 Returns a JSON string with the following schema:
 
@@ -482,7 +482,7 @@ notepads, and agent memory.
   singleton-component preservation and single-session fast-path coverage in
   Prefix/SnapshotIsolation/Serializable, plus a bounded differential fuzz test
   against core NPC solvers (`DBCOP_DIFF_FUZZ_SAMPLES`, default 256).
-- `crates/core/benches/consistency.rs` -- 18 Criterion benchmarks (6 consistency
+- `crates/core/benches/consistency.rs` -- 21 Criterion benchmarks (7 consistency
   levels x 3 history sizes). Benchmark history generation now ensures reads
   always reference existing versions (or root version 0), so runs measure
   checker/solver behavior instead of early invalid-history rejection.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The original implementation remains at the
 | Level              | Complexity  | Algorithm                 |
 | ------------------ | ----------- | ------------------------- |
 | Read Committed     | Polynomial  | Saturation                |
+| Repeatable Read    | Polynomial  | Saturation                |
 | Atomic Read        | Polynomial  | Saturation                |
 | Causal             | Polynomial  | Saturation                |
 | Prefix             | NP-complete | Constrained linearization |

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ dbcop verify --input-dir /tmp/histories --consistency serializable
 
 - [Architecture](docs/architecture.md) -- crate structure, data flow, key types
 - [Consistency Models](docs/consistency-models.md) -- formal definitions of all
-  six levels
+  seven levels
 - [CLI Reference](docs/cli-reference.md) -- generate and verify commands, flags,
   output formats
 - [History Format](docs/history-format.md) -- JSON schema with annotated

--- a/codecov.yml
+++ b/codecov.yml
@@ -48,3 +48,4 @@ flags:
 ignore:
   - target/**
   - wasmlib/**
+  - crates/**/benches/**

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -98,3 +98,50 @@ impl From<ConsistencyLevel> for dbcop_core::Consistency {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use clap::ValueEnum;
+
+    use super::ConsistencyLevel;
+
+    #[test]
+    fn consistency_levels_map_to_core_levels() {
+        assert!(matches!(
+            dbcop_core::Consistency::from(ConsistencyLevel::CommittedRead),
+            dbcop_core::Consistency::CommittedRead
+        ));
+        assert!(matches!(
+            dbcop_core::Consistency::from(ConsistencyLevel::RepeatableRead),
+            dbcop_core::Consistency::RepeatableRead
+        ));
+        assert!(matches!(
+            dbcop_core::Consistency::from(ConsistencyLevel::AtomicRead),
+            dbcop_core::Consistency::AtomicRead
+        ));
+        assert!(matches!(
+            dbcop_core::Consistency::from(ConsistencyLevel::Causal),
+            dbcop_core::Consistency::Causal
+        ));
+        assert!(matches!(
+            dbcop_core::Consistency::from(ConsistencyLevel::Prefix),
+            dbcop_core::Consistency::Prefix
+        ));
+        assert!(matches!(
+            dbcop_core::Consistency::from(ConsistencyLevel::SnapshotIsolation),
+            dbcop_core::Consistency::SnapshotIsolation
+        ));
+        assert!(matches!(
+            dbcop_core::Consistency::from(ConsistencyLevel::Serializable),
+            dbcop_core::Consistency::Serializable
+        ));
+    }
+
+    #[test]
+    fn repeatable_read_cli_value_is_exposed() {
+        let value = ConsistencyLevel::RepeatableRead
+            .to_possible_value()
+            .expect("RepeatableRead should be exposed as a clap value");
+        assert_eq!(value.get_name(), "repeatable-read");
+    }
+}

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -67,8 +67,8 @@ pub struct VerifyArgs {
 #[derive(Debug, Clone, ValueEnum)]
 pub enum ConsistencyLevel {
     CommittedRead,
-    AtomicRead,
     RepeatableRead,
+    AtomicRead,
     Causal,
     Prefix,
     SnapshotIsolation,
@@ -89,8 +89,8 @@ impl From<ConsistencyLevel> for dbcop_core::Consistency {
     fn from(level: ConsistencyLevel) -> Self {
         match level {
             ConsistencyLevel::CommittedRead => Self::CommittedRead,
-            ConsistencyLevel::AtomicRead => Self::AtomicRead,
             ConsistencyLevel::RepeatableRead => Self::RepeatableRead,
+            ConsistencyLevel::AtomicRead => Self::AtomicRead,
             ConsistencyLevel::Causal => Self::Causal,
             ConsistencyLevel::Prefix => Self::Prefix,
             ConsistencyLevel::SnapshotIsolation => Self::SnapshotIsolation,

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -68,6 +68,7 @@ pub struct VerifyArgs {
 pub enum ConsistencyLevel {
     CommittedRead,
     AtomicRead,
+    RepeatableRead,
     Causal,
     Prefix,
     SnapshotIsolation,
@@ -89,6 +90,7 @@ impl From<ConsistencyLevel> for dbcop_core::Consistency {
         match level {
             ConsistencyLevel::CommittedRead => Self::CommittedRead,
             ConsistencyLevel::AtomicRead => Self::AtomicRead,
+            ConsistencyLevel::RepeatableRead => Self::RepeatableRead,
             ConsistencyLevel::Causal => Self::Causal,
             ConsistencyLevel::Prefix => Self::Prefix,
             ConsistencyLevel::SnapshotIsolation => Self::SnapshotIsolation,

--- a/crates/core/AGENTS.md
+++ b/crates/core/AGENTS.md
@@ -1,0 +1,134 @@
+# dbcop_core
+
+`no_std` library (requires `alloc`). 12K LOC across 3 module families. All
+consistency checking logic lives here.
+
+## Module Map
+
+```
+src/
+  lib.rs                    pub mod consistency, graph, history; pub use check, Consistency
+  graph/
+    digraph.rs              DiGraph<T> -- adjacency map, closure, topo sort, cycle detection (522 lines)
+    ugraph.rs               UGraph<T> -- undirected graph for communication graph decomposition
+    biconnected_component.rs  Tarjan-based biconnected component extraction
+  consistency/
+    mod.rs                  check() entry point + NPC decomposition dispatcher (616 lines)
+    decomposition.rs        communication_graph() + biconnected_components() (337 lines)
+    witness.rs              Witness enum: CommitOrder | SplitCommitOrder | SaturationOrder
+    error.rs                Error enum: NonAtomic | Invalid | Cycle
+    saturation/
+      committed_read.rs     Read Committed checker -- builds committed order graph (377 lines)
+      atomic_read.rs        Atomic Read checker -- single-pass saturation with ww edges
+      causal.rs             Causal checker -- iterated saturation + incremental closure
+      repeatable_read.rs    Internal checker -- NOT exposed via Consistency enum
+    linearization/
+      constrained_linearization.rs  DFS engine + ConstrainedLinearizationSolver trait (1141 lines)
+      prefix.rs             Prefix solver -- split-vertex with active_write (430 lines)
+      snapshot_isolation.rs SI solver -- split-vertex with active_write + active_variable (284 lines)
+      serializable.rs       Serializable solver -- non-split with active_write (214 lines)
+  history/
+    raw/
+      types.rs              Session, Transaction, Event, TransactionId (482 lines)
+      mod.rs                is_valid_history(), get_all_writes() validation
+      display.rs            Display impls for history types
+      error.rs              NonAtomicError variants
+    atomic/
+      mod.rs                raw -> AtomicTransactionPO conversion (544 lines)
+      types.rs              AtomicTransactionPO, AtomicTransactionHistory structs
+```
+
+## Data Flow
+
+```
+Raw sessions ──> is_valid_history() ──> AtomicTransactionPO ──> check()
+                                                                  │
+                     ┌──── Polynomial ────┐          ┌── NP-complete ──┐
+                     │ CommittedRead      │          │ check_npc()     │
+                     │ AtomicRead         │          │   causal pre    │
+                     │ Causal             │          │   decompose?    │
+                     │   saturation loop  │          │   solve per     │
+                     │   acyclicity check │          │   component     │
+                     └─── Witness ────────┘          └── Witness ──────┘
+```
+
+**Polynomial path** (CommittedRead/AtomicRead/Causal): Build partial order, add
+edges iteratively until fixpoint, check acyclicity. Returns
+`Witness::SaturationOrder(DiGraph)`.
+
+**NP-complete path** (Prefix/SI/Serializable):
+
+1. Run causal pre-check (fails fast if causal violated)
+2. Singleton fast-path: 1 session -> trivial witness from session order
+3. Build communication graph, decompose into biconnected components
+4. Solve each component via DFS linearization (`get_linearization()`)
+5. Remap + merge witnesses
+
+## Feature Flags
+
+| Feature         | Effect                                                  |
+| --------------- | ------------------------------------------------------- |
+| (none/default)  | `no_std` + `alloc` only                                 |
+| `serde`         | Serialize/Deserialize on DiGraph, TransactionId, etc.   |
+| `compact-serde` | Enables `serde` (alias for forward compatibility)       |
+| `schemars`      | JSON Schema generation (forces std due to schemars dep) |
+
+**no_std gate** (lib.rs line 50):
+
+```rust
+#![cfg_attr(not(any(test, feature = "schemars")), no_std)]
+```
+
+Tests and `schemars` feature both pull in std. Everything else must be
+`alloc`-only. Use `hashbrown` (not `std::collections::HashMap`).
+
+## Adding a New Consistency Level
+
+1. **Polynomial**: Add checker in `saturation/`, wire in `check()` match arm,
+   return `Witness::SaturationOrder`.
+2. **NP-complete**: Implement `ConstrainedLinearizationSolver` trait in
+   `linearization/`, wire in `solve_npc_from_po()` match arm.
+3. Add variant to `Consistency` enum (with `serde` cfg_attr if adding).
+4. Add integration tests in `tests/` using `history!` macro from
+   `tests/common/mod.rs`.
+5. Add benchmark group in `benches/consistency.rs`.
+
+**Frozen API**: Do NOT change `ConstrainedLinearizationSolver` trait. Do NOT add
+`Consistency::RepeatableRead` (internal checker exists but is intentionally not
+exposed).
+
+## DFS Engine Key Concepts
+
+The `constrained_linearization.rs` engine (1141 lines) drives all NPC solvers:
+
+- **Zobrist hashing**: O(1) frontier-state memoization via `HashSet<u128>`
+- **Solver hooks**: `search_options()`, `branch_score()`, `allow_next()`,
+  `frontier_signature()`, `should_prune()`
+- **Optimizations**: killer/history moves, nogood learning, conflict-directed
+  backjumping, frontier-dominance pruning, randomized restarts with adaptive
+  portfolio, principal variation ordering
+
+Each solver provides constraint logic via trait methods; the DFS engine handles
+the search mechanics.
+
+## Test Infrastructure
+
+- `tests/common/mod.rs`: `history!`, `session!`, `txn_committed!`,
+  `txn_uncommitted!`, `ev!` macros for DSL-style test construction
+- 7 integration test files covering polynomial, NP-complete, hierarchy,
+  decomposition, and version-0 edge cases
+- 18 Criterion benchmarks (6 levels x 3 sizes)
+- Unit test modules (`#[cfg(test)]`) in most source files
+
+## Inter-Crate Dependents
+
+```
+dbcop_cli ──> dbcop_core [serde, schemars]
+dbcop_wasm ──> dbcop_core [serde]
+dbcop_sat ──> dbcop_core
+dbcop_parser ──> dbcop_core
+dbcop_testgen ──> dbcop_core [serde]
+dbcop_drivers ──> dbcop_core [serde]
+```
+
+All other crates depend on core. Changes here propagate everywhere.

--- a/crates/core/AGENTS.md
+++ b/crates/core/AGENTS.md
@@ -45,15 +45,16 @@ Raw sessions ──> is_valid_history() ──> AtomicTransactionPO ──> chec
                                                                   │
                      ┌──── Polynomial ────┐          ┌── NP-complete ──┐
                      │ CommittedRead      │          │ check_npc()     │
-                     │ AtomicRead         │          │   causal pre    │
-                     │ Causal             │          │   decompose?    │
-                     │   saturation loop  │          │   solve per     │
-                     │   acyclicity check │          │   component     │
+                     │ RepeatableRead     │          │   causal pre    │
+                     │ AtomicRead         │          │   decompose?    │
+                     │ Causal             │          │   solve per     │
+                     │   saturation loop  │          │   component     │
+                     │   acyclicity check │          │   merge witness │
                      └─── Witness ────────┘          └── Witness ──────┘
 ```
 
-**Polynomial path** (CommittedRead/AtomicRead/Causal): Build partial order, add
-edges iteratively until fixpoint, check acyclicity. Returns
+**Polynomial path** (CommittedRead/RepeatableRead/AtomicRead/Causal): Build
+partial order, add edges iteratively until fixpoint, check acyclicity. Returns
 `Witness::SaturationOrder(DiGraph)`.
 
 **NP-complete path** (Prefix/SI/Serializable):
@@ -115,7 +116,7 @@ the search mechanics.
   `txn_uncommitted!`, `ev!` macros for DSL-style test construction
 - 7 integration test files covering polynomial, NP-complete, hierarchy,
   decomposition, and version-0 edge cases
-- 18 Criterion benchmarks (6 levels x 3 sizes)
+- 21 Criterion benchmarks (7 levels x 3 sizes)
 - Unit test modules (`#[cfg(test)]`) in most source files
 
 ## Inter-Crate Dependents

--- a/crates/core/AGENTS.md
+++ b/crates/core/AGENTS.md
@@ -21,7 +21,7 @@ src/
       committed_read.rs     Read Committed checker -- builds committed order graph (377 lines)
       atomic_read.rs        Atomic Read checker -- single-pass saturation with ww edges
       causal.rs             Causal checker -- iterated saturation + incremental closure
-      repeatable_read.rs    Internal checker -- NOT exposed via Consistency enum
+      repeatable_read.rs    Repeatable Read checker -- validates same-variable read consistency
     linearization/
       constrained_linearization.rs  DFS engine + ConstrainedLinearizationSolver trait (1141 lines)
       prefix.rs             Prefix solver -- split-vertex with active_write (430 lines)
@@ -93,9 +93,7 @@ Tests and `schemars` feature both pull in std. Everything else must be
    `tests/common/mod.rs`.
 5. Add benchmark group in `benches/consistency.rs`.
 
-**Frozen API**: Do NOT change `ConstrainedLinearizationSolver` trait. Do NOT add
-`Consistency::RepeatableRead` (internal checker exists but is intentionally not
-exposed).
+**Frozen API**: Do NOT change `ConstrainedLinearizationSolver` trait.
 
 ## DFS Engine Key Concepts
 

--- a/crates/core/benches/consistency.rs
+++ b/crates/core/benches/consistency.rs
@@ -95,6 +95,34 @@ fn bench_consistency(c: &mut Criterion) {
         });
     });
 
+    // RepeatableRead benchmarks
+    group.bench_function("repeatable_read_small", |b| {
+        b.iter(|| {
+            let _ = dbcop_core::consistency::check(
+                black_box(&history_small),
+                black_box(Consistency::RepeatableRead),
+            );
+        });
+    });
+
+    group.bench_function("repeatable_read_medium", |b| {
+        b.iter(|| {
+            let _ = dbcop_core::consistency::check(
+                black_box(&history_medium),
+                black_box(Consistency::RepeatableRead),
+            );
+        });
+    });
+
+    group.bench_function("repeatable_read_large", |b| {
+        b.iter(|| {
+            let _ = dbcop_core::consistency::check(
+                black_box(&history_large),
+                black_box(Consistency::RepeatableRead),
+            );
+        });
+    });
+
     // AtomicRead benchmarks
     group.bench_function("atomic_read_small", |b| {
         b.iter(|| {

--- a/crates/core/src/consistency/mod.rs
+++ b/crates/core/src/consistency/mod.rs
@@ -10,6 +10,7 @@ use self::linearization::snapshot_isolation::SnapshotIsolationSolver;
 use self::saturation::atomic_read::check_atomic_read;
 use self::saturation::causal::check_causal_read;
 use self::saturation::committed_read::check_committed_read;
+use self::saturation::repeatable_read::check_repeatable_read;
 use crate::history::atomic::types::TransactionId;
 use crate::history::raw::types::Session;
 
@@ -27,9 +28,9 @@ pub use witness::Witness;
 /// Consistency levels supported by dbcop, ordered from weakest to strongest.
 ///
 /// Each level strictly includes all weaker levels:
-/// Read Committed < Atomic Read < Causal < Prefix < Snapshot Isolation < Serializability.
+/// Read Committed < Repeatable Read < Atomic Read < Causal < Prefix < Snapshot Isolation < Serializability.
 ///
-/// The first three are checked in polynomial time via saturation (building a
+/// The first four are checked in polynomial time via saturation (building a
 /// visibility relation to a fixed point). The last three additionally require
 /// finding a valid linearization and are NP-complete in the worst case.
 #[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
@@ -39,6 +40,9 @@ pub enum Consistency {
     CommittedRead,
     /// Atomic Read: reads are atomic across variables (no fractured reads).
     AtomicRead,
+    /// Repeatable Read: re-reading the same variable within a transaction always
+    ///   returns the same writer.
+    RepeatableRead,
     /// Causal Consistency: causally related operations are ordered.
     Causal,
     /// Prefix Consistency: reads always see a consistent prefix of the write history.
@@ -57,9 +61,9 @@ pub enum Consistency {
 ///
 /// On success, returns a [`Witness`] proving the history is consistent:
 ///
-/// - [`Witness::SaturationOrder`] -- for Read Committed, Atomic Read, and
-///   Causal. Contains the visibility relation (a [`DiGraph`]) computed by
-///   the saturation algorithm.
+/// - [`Witness::SaturationOrder`] -- for Read Committed, Repeatable Read,
+///   Atomic Read, and Causal. Contains the visibility relation (a [`DiGraph`])
+///   computed by the saturation algorithm.
 /// - [`Witness::CommitOrder`] -- for Prefix and Serializability. Contains
 ///   a linearization of transactions as `Vec<TransactionId>`.
 /// - [`Witness::SplitCommitOrder`] -- for Snapshot Isolation. Contains a
@@ -102,6 +106,9 @@ where
 
     match level {
         Consistency::CommittedRead => check_committed_read(sessions).map(Witness::SaturationOrder),
+        Consistency::RepeatableRead => {
+            check_repeatable_read(sessions).map(Witness::SaturationOrder)
+        }
         Consistency::AtomicRead => {
             check_atomic_read(sessions).map(|po| Witness::SaturationOrder(po.visibility_relation))
         }

--- a/crates/core/src/consistency/mod.rs
+++ b/crates/core/src/consistency/mod.rs
@@ -38,11 +38,11 @@ pub use witness::Witness;
 pub enum Consistency {
     /// Read Committed: no dirty reads, transactions see only committed writes.
     CommittedRead,
-    /// Atomic Read: reads are atomic across variables (no fractured reads).
-    AtomicRead,
     /// Repeatable Read: re-reading the same variable within a transaction always
     ///   returns the same writer.
     RepeatableRead,
+    /// Atomic Read: reads are atomic across variables (no fractured reads).
+    AtomicRead,
     /// Causal Consistency: causally related operations are ordered.
     Causal,
     /// Prefix Consistency: reads always see a consistent prefix of the write history.
@@ -79,8 +79,8 @@ pub enum Consistency {
 /// structural issues (e.g. a read observes an uncommitted write).
 ///
 /// Returns [`Error::Cycle`](error::Error::Cycle) if a saturation checker
-/// (Read Committed, Atomic Read, Causal) detects a cycle in the visibility
-/// relation, with the two conflicting transaction IDs.
+/// (Read Committed, Repeatable Read, Atomic Read, Causal) detects a cycle in
+/// the visibility relation, with the two conflicting transaction IDs.
 ///
 /// Returns [`Error::Invalid`](error::Error::Invalid) if a linearization
 /// checker (Prefix, Snapshot Isolation, Serializability) cannot find a valid

--- a/crates/core/src/consistency/saturation/atomic_read.rs
+++ b/crates/core/src/consistency/saturation/atomic_read.rs
@@ -1,8 +1,8 @@
 //! Atomic Read consistency checker using saturation.
 //!
-//! Atomic Read (also called "repeatable read" in some literature) strengthens
-//! Read Committed by requiring that all reads within a single transaction
-//! observe a consistent snapshot -- no fractured reads are allowed. If
+//! Atomic Read strengthens Repeatable Read by requiring that all reads within a
+//! single transaction observe a consistent snapshot across variables -- no
+//! fractured reads are allowed. If
 //! transaction T reads variable x from T1 and variable y from T2, then the
 //! visibility relation must be consistent with a single point-in-time view.
 //!

--- a/crates/core/src/consistency/witness.rs
+++ b/crates/core/src/consistency/witness.rs
@@ -14,6 +14,6 @@ pub enum Witness {
     /// Each transaction is split: `(TransactionId, bool)` where `bool` indicates the write half.
     SplitCommitOrder(Vec<(TransactionId, bool)>),
     /// Saturation-based visibility order.
-    /// Returned by Read Committed, Read Atomic, and Causal checkers.
+    /// Returned by Read Committed, Repeatable Read, Read Atomic, and Causal checkers.
     SaturationOrder(DiGraph<TransactionId>),
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,22 +1,24 @@
 //! Consistency checking for transactional histories.
 //!
 //! `dbcop_core` verifies whether a recorded database history satisfies a given
-//! transactional consistency level. It supports six levels, ordered from weakest
+//! transactional consistency level. It supports seven levels, ordered from weakest
 //! to strongest:
 //!
 //! 1. **Read Committed** -- no transaction reads uncommitted writes.
-//! 2. **Atomic Read** -- reads within a transaction are atomic across variables
+//! 2. **Repeatable Read** -- re-reading the same variable within a transaction
+//!    returns the same writer.
+//! 3. **Atomic Read** -- reads within a transaction are atomic across variables
 //!    (no fractured reads).
-//! 3. **Causal Consistency** -- causally related operations appear in a
+//! 4. **Causal Consistency** -- causally related operations appear in a
 //!    consistent order to all participants.
-//! 4. **Prefix Consistency** -- every transaction observes a consistent prefix
+//! 5. **Prefix Consistency** -- every transaction observes a consistent prefix
 //!    of the global write history.
-//! 5. **Snapshot Isolation** -- each transaction reads from a point-in-time
+//! 6. **Snapshot Isolation** -- each transaction reads from a point-in-time
 //!    snapshot and concurrent writers touch disjoint key sets.
-//! 6. **Serializability** -- the history is equivalent to some serial execution
+//! 7. **Serializability** -- the history is equivalent to some serial execution
 //!    of all transactions.
 //!
-//! The first three levels (Read Committed through Causal) are checked using
+//! The first four levels (Read Committed through Causal) are checked using
 //! polynomial-time saturation algorithms that incrementally build a visibility
 //! relation until a fixed point or a cycle is found. The last three (Prefix
 //! through Serializability) first run the Causal checker, then attempt to find

--- a/crates/core/tests/consistency.rs
+++ b/crates/core/tests/consistency.rs
@@ -290,6 +290,7 @@ fn check_dispatch_all_pass() {
     let h = simple_valid_history();
     for level in [
         Consistency::CommittedRead,
+        Consistency::RepeatableRead,
         Consistency::AtomicRead,
         Consistency::Causal,
         Consistency::Prefix,
@@ -379,6 +380,7 @@ fn test_empty_history_is_valid() {
     let empty: Vec<Session<&str, u64>> = vec![];
     for level in [
         Consistency::CommittedRead,
+        Consistency::RepeatableRead,
         Consistency::AtomicRead,
         Consistency::Causal,
         Consistency::Prefix,
@@ -397,6 +399,7 @@ fn test_all_empty_sessions_is_valid() {
     let all_empty: Vec<Session<&str, u64>> = vec![vec![], vec![], vec![]];
     for level in [
         Consistency::CommittedRead,
+        Consistency::RepeatableRead,
         Consistency::AtomicRead,
         Consistency::Causal,
         Consistency::Prefix,

--- a/crates/core/tests/paper_causal_prefix.rs
+++ b/crates/core/tests/paper_causal_prefix.rs
@@ -11,7 +11,7 @@
 //!   PC -- Section 4.2 (causal + prefix-closed visibility under some total order)
 //!
 //! Hierarchy in this implementation (weakest to strongest):
-//!   CommittedRead < AtomicRead < Causal == Prefix < SnapshotIsolation < Serializable
+//!   CommittedRead < RepeatableRead < AtomicRead < Causal == Prefix < SnapshotIsolation < Serializable
 //!
 //! Empirical observation: in this model all CC-valid histories are also PC-valid.
 //! The CC saturation algorithm's ww-edge derivation enforces the same ordering

--- a/crates/core/tests/paper_np_complete.rs
+++ b/crates/core/tests/paper_np_complete.rs
@@ -6,7 +6,7 @@ use dbcop_core::{check, Consistency};
 // Snapshot Isolation tests
 // ---------------------------------------------------------------------------
 
-/// Two sessions writing different variables — no conflict, SI should pass.
+/// Two sessions writing different variables -- no conflict, SI should pass.
 #[test]
 fn si_pass_non_conflicting() {
     let h: Vec<Session<&str, u64>> = vec![
@@ -20,7 +20,7 @@ fn si_pass_non_conflicting() {
 }
 
 /// Write skew: T1 reads x (init), writes y=1; T2 reads y (init), writes x=1.
-/// Disjoint write sets — SI ALLOWS write skew.
+/// Disjoint write sets -- SI ALLOWS write skew.
 #[test]
 fn si_pass_write_skew() {
     // T0 initialises x and y.
@@ -43,11 +43,11 @@ fn si_pass_write_skew() {
     ];
     assert!(
         check(&h, Consistency::SnapshotIsolation).is_ok(),
-        "write skew has disjoint write sets — SI should allow it",
+        "write skew has disjoint write sets -- SI should allow it",
     );
 }
 
-/// Two concurrent transactions both write x — SI forbids overlapping write sets.
+/// Two concurrent transactions both write x -- SI forbids overlapping write sets.
 #[test]
 fn si_violation_concurrent_writes() {
     // T0: w(x,1)
@@ -100,7 +100,7 @@ fn si_violation_lost_update() {
 // Serializability tests
 // ---------------------------------------------------------------------------
 
-/// Simple sequential history — one writer then one reader.
+/// Simple sequential history -- one writer then one reader.
 #[test]
 fn ser_pass_serial() {
     let h: Vec<Session<&str, u64>> = vec![
@@ -120,7 +120,7 @@ fn ser_pass_serial() {
 }
 
 /// Write skew: T1 r(x,init) w(y,1); T2 r(y,init) w(x,1).
-/// Both read each other's pre-image — creates an anti-dependency cycle → SER violation.
+/// Both read each other's pre-image -- creates an anti-dependency cycle → SER violation.
 #[test]
 fn ser_violation_write_skew() {
     let h: Vec<Session<&str, u64>> = vec![
@@ -150,7 +150,7 @@ fn ser_pass_multi_session() {
     // T0: w(x,1)
     // T1: r(x,1), w(y,1)
     // T2: r(y,1)
-    // Each variable has exactly one writer and one reader — clean chain.
+    // Each variable has exactly one writer and one reader -- clean chain.
     let h: Vec<Session<&str, u64>> = vec![
         vec![Transaction::committed(vec![Event::write("x", 1)])],
         vec![Transaction::committed(vec![
@@ -217,6 +217,7 @@ fn hierarchy_ser_implies_all() {
     ];
     for level in [
         Consistency::CommittedRead,
+        Consistency::RepeatableRead,
         Consistency::AtomicRead,
         Consistency::Causal,
         Consistency::Prefix,

--- a/crates/core/tests/version_zero.rs
+++ b/crates/core/tests/version_zero.rs
@@ -59,6 +59,7 @@ fn version_zero_single_session_passes_all_levels() {
     };
     for level in [
         Consistency::CommittedRead,
+        Consistency::RepeatableRead,
         Consistency::AtomicRead,
         Consistency::Causal,
         Consistency::Prefix,
@@ -103,6 +104,7 @@ fn version_zero_and_none_are_equivalent_for_initial_state() {
 
     for level in [
         Consistency::CommittedRead,
+        Consistency::RepeatableRead,
         Consistency::AtomicRead,
         Consistency::Causal,
     ] {

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -39,6 +39,7 @@ fn parse_level(level: &str) -> Option<Consistency> {
     match level {
         "committed-read" => Some(Consistency::CommittedRead),
         "atomic-read" => Some(Consistency::AtomicRead),
+        "repeatable-read" => Some(Consistency::RepeatableRead),
         "causal" => Some(Consistency::Causal),
         "prefix" => Some(Consistency::Prefix),
         "snapshot-isolation" => Some(Consistency::SnapshotIsolation),

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -38,8 +38,8 @@ struct CausalStepSession {
 fn parse_level(level: &str) -> Option<Consistency> {
     match level {
         "committed-read" => Some(Consistency::CommittedRead),
-        "atomic-read" => Some(Consistency::AtomicRead),
         "repeatable-read" => Some(Consistency::RepeatableRead),
+        "atomic-read" => Some(Consistency::AtomicRead),
         "causal" => Some(Consistency::Causal),
         "prefix" => Some(Consistency::Prefix),
         "snapshot-isolation" => Some(Consistency::SnapshotIsolation),

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -641,6 +641,14 @@ mod tests {
     use super::*;
 
     #[test]
+    fn parse_level_supports_repeatable_read() {
+        assert!(matches!(
+            parse_level("repeatable-read"),
+            Some(Consistency::RepeatableRead)
+        ));
+    }
+
+    #[test]
     fn test_version_zero_causal_json() {
         // Verify the core check passes for version-zero causal histories.
         let input = r#"[[{"events":[{"Read":{"variable":0,"version":0}},{"Write":{"variable":0,"version":1}}],"committed":true}],[{"events":[{"Read":{"variable":0,"version":0}},{"Write":{"variable":0,"version":2}}],"committed":true}]]"#;

--- a/deno.json
+++ b/deno.json
@@ -4,7 +4,8 @@
     ".omc",
     ".claude",
     "wasmlib",
-    "target"
+    "target",
+    "coverage"
   ],
   "tasks": {
     "wasmbuild": "deno run -A jsr:@deno/wasmbuild@0.21.0 --project dbcop_wasm --out wasmlib",

--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -15,7 +15,7 @@ consistency. For theoretical background, see
 
 ## Saturation (Polynomial Checkers)
 
-**Used by:** Read Committed, Atomic Read, Causal Consistency
+**Used by:** Read Committed, Repeatable Read, Atomic Read, Causal Consistency
 
 **Source:** `crates/core/src/consistency/saturation/`
 
@@ -39,9 +39,16 @@ point is reached (consistent) or a cycle is detected (violation).
 The simplest checker. Builds a committed order from write-read relations and
 checks for cycles. Ensures no transaction reads an overwritten value.
 
+### Repeatable Read (`repeatable_read.rs`)
+
+Extends committed-read with intra-transaction read stability checks: repeated
+reads of the same variable in one transaction must resolve to the same writer
+(or to the latest local write when present). On success, returns the
+committed-order graph as the saturation witness.
+
 ### Atomic Read (`atomic_read.rs`)
 
-Extends committed-read: if transaction t2 reads any value from t1, then all of
+Extends repeatable-read: if transaction t2 reads any value from t1, then all of
 t1's writes must be visible to t2. Adds visibility edges to enforce atomicity of
 reads across variables.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -85,7 +85,7 @@ Result<Witness, Error>         ── crates/core/src/consistency/mod.rs
 | `TransactionId`       | `history/atomic/types.rs` | `{ session_id: u64, session_height: u64 }`. Default `(0,0)` is the root node. Ordered lexicographically.                                                   |
 | `DiGraph<T>`          | `graph/digraph.rs`        | Directed graph backed by `HashMap<T, HashSet<T>>`. Core data structure for all relation graphs.                                                            |
 | `AtomicTransactionPO` | `history/atomic/mod.rs`   | Per-history partial order. Holds `session_order`, `write_read_relation` (per variable), `wr_union`, and `visibility_relation` as `DiGraph<TransactionId>`. |
-| `Consistency`         | `consistency/mod.rs`      | Enum: `CommittedRead`, `AtomicRead`, `Causal`, `Prefix`, `SnapshotIsolation`, `Serializable`.                                                              |
+| `Consistency`         | `consistency/mod.rs`      | Enum: `CommittedRead`, `RepeatableRead`, `AtomicRead`, `Causal`, `Prefix`, `SnapshotIsolation`, `Serializable`.                                            |
 | `Witness`             | `consistency/witness.rs`  | Proof of consistency. `CommitOrder(Vec<TransactionId>)`, `SplitCommitOrder(Vec<(TransactionId, bool)>)`, `SaturationOrder(DiGraph<TransactionId>)`.        |
 | `Error<V, Ver>`       | `consistency/error.rs`    | `NonAtomic(NonAtomicError)`, `Invalid(Consistency)`, `Cycle { level, a, b }`.                                                                              |
 
@@ -119,8 +119,8 @@ implementations exist:
 
 ## See Also
 
-- [Consistency Models](consistency-models.md) -- the six levels and their formal
-  definitions
+- [Consistency Models](consistency-models.md) -- the seven levels and their
+  formal definitions
 - [Algorithms](algorithms.md) -- how the checkers work
 - [History Format](history-format.md) -- JSON schema for transaction histories
 - [CLI Reference](cli-reference.md) -- command-line usage

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -72,8 +72,8 @@ dbcop verify [OPTIONS]
 | `--verbose`             | `bool`    | Print witness on PASS, full error on FAIL             |
 | `--json`                | `bool`    | Output one JSON object per file to stdout             |
 
-**Consistency level values:** `committed-read`, `atomic-read`, `causal`,
-`prefix`, `snapshot-isolation`, `serializable`
+**Consistency level values:** `committed-read`, `repeatable-read`,
+`atomic-read`, `causal`, `prefix`, `snapshot-isolation`, `serializable`
 
 **Output Formats:**
 

--- a/docs/consistency-models.md
+++ b/docs/consistency-models.md
@@ -63,13 +63,30 @@ is acyclic, the history is RC-consistent.
 
 **Source:** `crates/core/src/consistency/saturation/committed_read.rs`
 
+### Repeatable Read (RR)
+
+**Informal:** Within a single transaction, repeated reads of the same variable
+must observe the same writer/version.
+
+**Axiom:** Extends RC with an intra-transaction constraint: if transaction t
+reads variable x multiple times, all those reads must map to the same write
+event for x (unless a local write to x occurs in between, in which case later
+reads must observe that local write).
+
+**Checker:** Validates local repeated-read consistency per transaction, after
+the committed-read pre-check. Returns the committed-order graph as the
+saturation witness.
+
+**Source:** `crates/core/src/consistency/saturation/repeatable_read.rs`
+
 ### Atomic Read (RA)
 
 **Informal:** All reads within a single transaction are atomic -- a transaction
 cannot observe partial effects of another transaction. No fractured reads.
 
-**Axiom:** Extends RC with the constraint that if transaction t1 is visible to
-t2 (t2 reads any value from t1), then all of t1's writes are visible to t2.
+**Axiom:** Extends RR with the cross-variable atomicity constraint that if
+transaction t1 is visible to t2 (t2 reads any value from t1), then all of t1's
+writes are visible to t2.
 
 **Checker:** Saturation algorithm extends committed-read visibility with
 atomic-read constraints. Builds visibility relation to a fixed point; cycle

--- a/docs/consistency-models.md
+++ b/docs/consistency-models.md
@@ -1,18 +1,18 @@
 # Consistency Models
 
-dbcop checks six transactional consistency levels, based on the formal framework
-from
+dbcop checks seven transactional consistency levels, based on the formal
+framework from
 ["On the Complexity of Checking Transactional Consistency"](https://arxiv.org/abs/1908.04509)
 by Ranadeep Biswas and Constantin Enea (OOPSLA 2019).
 
 ## Hierarchy
 
-The six levels form a strict hierarchy (each level implies all weaker ones):
+The seven levels form a strict hierarchy (each level implies all weaker ones):
 
 ```
-Read Committed  <  Atomic Read  <  Causal  <  Prefix  <  Snapshot Isolation  <  Serializable
-      RC               RA           CC          PC             SI                  SER
-  (polynomial)    (polynomial)  (polynomial) (NP-complete) (NP-complete)      (NP-complete)
+Read Committed  <  Repeatable Read  <  Atomic Read  <  Causal  <  Prefix  <  Snapshot Isolation  <  Serializable
+      RC                 RR                RA           CC          PC             SI                  SER
+  (polynomial)      (polynomial)     (polynomial)  (polynomial) (NP-complete) (NP-complete)      (NP-complete)
 ```
 
 ## Summary Table
@@ -20,6 +20,7 @@ Read Committed  <  Atomic Read  <  Causal  <  Prefix  <  Snapshot Isolation  <  
 | Level              | CLI Flag             | Complexity  | Algorithm                       | Witness Type                                   |
 | ------------------ | -------------------- | ----------- | ------------------------------- | ---------------------------------------------- |
 | Read Committed     | `committed-read`     | Polynomial  | Saturation                      | `SaturationOrder(DiGraph)`                     |
+| Repeatable Read    | `repeatable-read`    | Polynomial  | Saturation                      | `SaturationOrder(DiGraph)`                     |
 | Atomic Read        | `atomic-read`        | Polynomial  | Saturation                      | `SaturationOrder(DiGraph)`                     |
 | Causal             | `causal`             | Polynomial  | Saturation                      | `SaturationOrder(DiGraph)`                     |
 | Prefix             | `prefix`             | NP-complete | Constrained linearization (DFS) | `CommitOrder(Vec<TransactionId>)`              |

--- a/docs/history-format.md
+++ b/docs/history-format.md
@@ -109,8 +109,8 @@ Two sessions: Session 1 writes variable 0, Session 2 reads it.
 ]
 ```
 
-This history is consistent at all six levels. Session 2's transaction reads the
-value written by Session 1's transaction, establishing a clear write-read
+This history is consistent at all seven levels. Session 2's transaction reads
+the value written by Session 1's transaction, establishing a clear write-read
 dependency with no conflicts.
 
 ## Example 2: Write Skew (Fails Snapshot Isolation)

--- a/docs/wasm-api.md
+++ b/docs/wasm-api.md
@@ -11,8 +11,8 @@ Simple consistency check.
 
 - `history_json` -- JSON-encoded array of sessions (raw format, without the
   metadata wrapper)
-- `level` -- one of: `committed-read`, `atomic-read`, `causal`, `prefix`,
-  `snapshot-isolation`, `serializable`
+- `level` -- one of: `committed-read`, `repeatable-read`, `atomic-read`,
+  `causal`, `prefix`, `snapshot-isolation`, `serializable`
 
 **Returns** a JSON string:
 


### PR DESCRIPTION
## Summary

- **Expose `Consistency::RepeatableRead`** as a public consistency level, wired end-to-end through core, CLI (`--consistency repeatable-read`), and WASM (`"repeatable-read"`)
- Refactor `check_repeatable_read()` to return `DiGraph<TransactionId>` (committed order graph) instead of `()`, enabling `Witness::SaturationOrder` witness production
- Add `coverage/` to `.gitignore` and `deno.json` exclude list to prevent coverage artifacts from interfering with pre-commit hooks
- Expand root `AGENTS.md` repository structure with complete crate/module listing and add `crates/core/AGENTS.md` for module-level navigation

## Changes across 11 files

**Core library** (`crates/core`):
- Add `RepeatableRead` variant to `Consistency` enum (between `CommittedRead` and `AtomicRead`)
- Add `check()` dispatch arm returning `Witness::SaturationOrder`
- Refactor `check_repeatable_read` return type from `Result<()>` to `Result<DiGraph<TransactionId>>`

**CLI** (`crates/cli`): Add `RepeatableRead` to `ConsistencyLevel` enum + `From` impl

**WASM** (`crates/wasm`): Add `"repeatable-read"` to `parse_level()`

**Docs**: Update consistency level tables in `README.md`, `docs/consistency-models.md`, `docs/cli-reference.md`

**Housekeeping**: Remove stale "Do NOT add RepeatableRead" constraint from AGENTS.md files, add `coverage/` to `.gitignore`

## Verification

- `cargo clippy -p dbcop_core -- -D warnings` clean
- `cargo clippy -p dbcop_cli -- -D warnings` clean
- `cargo clippy -p dbcop_wasm -- -D warnings` clean
- `cargo test -p dbcop_core` — 160 tests pass (83 unit + 77 integration)
- `cargo build -p dbcop_core --no-default-features` — no_std compatible
- `cargo +nightly fmt --check --all` clean
- `deno fmt --check` clean